### PR TITLE
feat(overlay): keyless mpv controls for labels/objects/trails/heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,30 @@ cap). Studio drains mpv's IPC responses in a dedicated reader thread,
 so a long playback session can't fill the kernel reply buffer and
 freeze mpv's main thread.
 
+#### Controlling the overlay from mpv
+
+The overlay script grabs **no keys by default** (mpv convention: you own
+your `input.conf`). It exposes named, keyless bindings — map your own
+keys with `script-binding omniphony-overlay/<name>`, or drive them from
+any client with `script-message omniphony-overlay <name>`:
+
+| Binding / message     | Action                                           |
+| --------------------- | ------------------------------------------------ |
+| `toggle`              | master overlay on/off                            |
+| `labels`              | object-name labels on/off                        |
+| `objects`             | objects (markers + trails + depth lines) on/off  |
+| `trails`              | motion trails on/off                             |
+| `heatmap`             | energy heatmap field on/off                      |
+| `heatmap-colormap`    | cycle the heatmap gradient                       |
+| `heatmap-bands-inc` / `heatmap-bands-dec` | more / fewer heatmap depth planes |
+
+Each toggle flips the control inside liborender and reports the new state
+in the OSD, so it stays in sync with Studio's OSC changes. See
+[`runtime/input.conf.example`](runtime/input.conf.example) for a ready-to-copy
+set of bindings. (The toggles need liborender ABI ≥ 0.4; on an older
+library the script still loads and `toggle` works, but the sub-controls
+report "unavailable".)
+
 ## mpv fork workflow
 
 Develop the integration in a fork of `mpv-player/mpv`:

--- a/runtime/input.conf.example
+++ b/runtime/input.conf.example
@@ -1,0 +1,17 @@
+# Omniphony spatial overlay — example key bindings.
+#
+# The overlay script (omniphony-overlay.lua) grabs NO keys by default, following
+# mpv convention: you own your input.conf. Copy the lines you want into your own
+# input.conf (uncomment and pick your keys). Each command is also reachable via
+#   script-message omniphony-overlay <toggle|labels|objects|trails|heatmap|colormap|bands-inc|bands-dec|enable|disable>
+#
+# Form: <key>  script-binding omniphony-overlay/<name>
+
+Ctrl+o  script-binding omniphony-overlay/toggle              # master on/off
+#l      script-binding omniphony-overlay/labels              # object name labels
+#o      script-binding omniphony-overlay/objects             # objects (markers + trails + depth lines)
+#t      script-binding omniphony-overlay/trails              # motion trails
+#h      script-binding omniphony-overlay/heatmap             # energy heatmap field
+#c      script-binding omniphony-overlay/heatmap-colormap    # cycle heatmap gradient
+#=      script-binding omniphony-overlay/heatmap-bands-inc   # more heatmap depth planes
+#-      script-binding omniphony-overlay/heatmap-bands-dec   # fewer heatmap depth planes

--- a/runtime/omniphony-overlay.lua
+++ b/runtime/omniphony-overlay.lua
@@ -39,6 +39,16 @@ ffi.cdef([[
   void orender_overlay_set_enabled(int enabled);
   size_t orender_overlay_heatmap_bgra(uint32_t res_x, uint32_t res_y,
                                       uint8_t *out, size_t cap, int32_t *geom);
+  /* Per-control toggles (liborender ABI >= 0.4). Each flips the control and
+     returns the new state (1/0 for booleans, the new value for the heatmap
+     band/colormap variants). Absent on older libraries — guarded at runtime. */
+  int orender_overlay_toggle(void);
+  int orender_overlay_toggle_labels(void);
+  int orender_overlay_toggle_objects(void);
+  int orender_overlay_toggle_trails(void);
+  int orender_overlay_toggle_heatmap(void);
+  uint32_t orender_overlay_cycle_heatmap_colormap(void);
+  uint32_t orender_overlay_adjust_heatmap_bands(int32_t delta);
 ]])
 
 -- liborender is already resident in the mpv process: the patched mpv links it
@@ -190,6 +200,29 @@ mp.add_periodic_timer(1 / REDRAW_HZ, redraw)
 mp.observe_property("osd-width", "number", function() redraw() end)
 mp.observe_property("osd-height", "number", function() redraw() end)
 
+-- ── controls ─────────────────────────────────────────────────────────────
+-- Following mpv convention, controls are exposed as *named* bindings (no keys
+-- grabbed by default) plus a `script-message`; the user binds keys in their own
+-- input.conf (see input.conf.example). Each toggle flips the control inside
+-- liborender and shows the resulting state in the OSD; the renderer is the
+-- single source of truth, so this stays in sync with Studio's OSC changes.
+
+local function osd(msg)
+  mp.osd_message(msg, 1)
+end
+
+local function on_off(v)
+  return v ~= 0 and "on" or "off"
+end
+
+-- Is an (ABI >= 0.4) FFI symbol present? Older liborender lacks the toggles; we
+-- degrade gracefully rather than erroring out the whole script.
+local function has_sym(name)
+  return pcall(function() return C[name] end)
+end
+
+-- Absolute master enable/disable. Also gates this script's redraw timer and
+-- hides both OSD layers when off.
 local function set_active(on)
   enabled = on
   C.orender_overlay_set_enabled(on and 1 or 0)
@@ -201,21 +234,70 @@ local function set_active(on)
   end
 end
 
--- Manual control (external client / script-message).
-mp.register_script_message("omniphony-overlay", function(cmd)
-  if cmd == "enable" then
-    set_active(true)
-  elseif cmd == "disable" then
-    set_active(false)
-  elseif cmd == "toggle" then
+-- Master toggle: flip in the library (returns the new state) so it tracks
+-- Studio's OSC changes; fall back to the local mirror on older libraries.
+local function toggle_master()
+  if has_sym("orender_overlay_toggle") then
+    enabled = C.orender_overlay_toggle() ~= 0
+    if enabled then redraw() else hide(); hide_heatmap() end
+  else
     set_active(not enabled)
   end
-end)
+  osd("Spatial overlay: " .. on_off(enabled and 1 or 0))
+end
 
--- Default keybind so the overlay can be toggled without studio (rebindable in
--- input.conf via the `omniphony-overlay-toggle` command name).
-mp.add_key_binding("Ctrl+o", "omniphony-overlay-toggle", function()
-  set_active(not enabled)
+-- Generic boolean sub-toggle (labels / objects / trails / heatmap).
+local function bool_toggle(sym, label)
+  if not has_sym(sym) then
+    osd(label .. ": unavailable (update liborender)")
+    return
+  end
+  osd(label .. ": " .. on_off(C[sym]()))
+  redraw()
+end
+
+local function cycle_colormap()
+  if not has_sym("orender_overlay_cycle_heatmap_colormap") then
+    osd("Heatmap colormap: unavailable (update liborender)")
+    return
+  end
+  osd("Heatmap colormap: " .. tonumber(C.orender_overlay_cycle_heatmap_colormap()))
+  redraw()
+end
+
+local function adjust_bands(delta)
+  if not has_sym("orender_overlay_adjust_heatmap_bands") then
+    osd("Heatmap planes: unavailable (update liborender)")
+    return
+  end
+  osd("Heatmap planes: " .. tonumber(C.orender_overlay_adjust_heatmap_bands(delta)))
+  redraw()
+end
+
+-- Named, keyless bindings — the user maps keys via
+-- `script-binding omniphony-overlay/<name>` in input.conf.
+mp.add_key_binding(nil, "toggle", toggle_master)
+mp.add_key_binding(nil, "labels", function() bool_toggle("orender_overlay_toggle_labels", "Overlay labels") end)
+mp.add_key_binding(nil, "objects", function() bool_toggle("orender_overlay_toggle_objects", "Overlay objects") end)
+mp.add_key_binding(nil, "trails", function() bool_toggle("orender_overlay_toggle_trails", "Overlay trails") end)
+mp.add_key_binding(nil, "heatmap", function() bool_toggle("orender_overlay_toggle_heatmap", "Energy heatmap") end)
+mp.add_key_binding(nil, "heatmap-colormap", cycle_colormap)
+mp.add_key_binding(nil, "heatmap-bands-inc", function() adjust_bands(1) end)
+mp.add_key_binding(nil, "heatmap-bands-dec", function() adjust_bands(-1) end)
+
+-- Manual control (external client / `script-message omniphony-overlay <cmd>`).
+mp.register_script_message("omniphony-overlay", function(cmd)
+  if cmd == "enable" then set_active(true)
+  elseif cmd == "disable" then set_active(false)
+  elseif cmd == "toggle" then toggle_master()
+  elseif cmd == "labels" then bool_toggle("orender_overlay_toggle_labels", "Overlay labels")
+  elseif cmd == "objects" then bool_toggle("orender_overlay_toggle_objects", "Overlay objects")
+  elseif cmd == "trails" then bool_toggle("orender_overlay_toggle_trails", "Overlay trails")
+  elseif cmd == "heatmap" then bool_toggle("orender_overlay_toggle_heatmap", "Energy heatmap")
+  elseif cmd == "colormap" then cycle_colormap()
+  elseif cmd == "bands-inc" then adjust_bands(1)
+  elseif cmd == "bands-dec" then adjust_bands(-1)
+  end
 end)
 
 -- Clear on shutdown so the OSD doesn't linger past quit.


### PR DESCRIPTION
## Why

The overlay shim could only toggle the whole overlay (hardcoded `Ctrl+o`). This exposes the rest of the controls — labels, objects, trails, the energy heatmap and its planes/colormap — that previously required Studio + OSC, directly from mpv.

## Approach (mpv conventions)

No keys grabbed by default — the user owns `input.conf`. The script registers **named, keyless bindings** (`script-binding omniphony-overlay/<name>`) plus a matching `script-message`, and ships [`runtime/input.conf.example`](runtime/input.conf.example) to copy from. The former `Ctrl+o` default is removed from the script and lives in the example instead.

| Binding / message | Action |
| --- | --- |
| `toggle` | master on/off |
| `labels` / `objects` / `trails` / `heatmap` | sub-control on/off |
| `heatmap-colormap` | cycle gradient |
| `heatmap-bands-inc` / `heatmap-bands-dec` | more / fewer depth planes |

Each toggle calls the new liborender FFI (**ABI ≥ 0.4**, companion PR `mgth/Omniphony#21`), which flips the control inside the renderer and returns the new state; the shim shows it in the OSD and stays in sync with Studio's OSC changes.

## Graceful degradation

Missing symbols (older liborender) are detected per-symbol: the script still loads, `toggle` works, and sub-controls report "unavailable" instead of erroring out.

## Verification

Lua syntax validated with `luajit`. Full runtime check (toggles + OSD in mpv) requires a redistributed liborender built from the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)