### PR TITLE
patches: ProgramData config path in the ad_orender Windows hint

### DIFF
--- a/patches-master/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches-master/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/10] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/11] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches-master/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/10] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/11] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches-master/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches-master/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/10] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/11] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches-master/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches-master/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/10] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/11] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches-master/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches-master/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/10] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/11] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches-master/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/10] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/11] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches-master/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/10] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/11] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches-master/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/10] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/11] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches-master/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches-master/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/10] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/11] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches-master/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/10] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/11] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches-master/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches-master/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Sat, 13 Jun 2026 11:10:05 +0200
+Subject: [PATCH 11/11] ad_orender: ProgramData config path in the Windows
+ bridge_path hint
+
+The renderer's Windows default config moved to %ProgramData%\omniphony\
+config.yaml (machine-wide, shared between user mode and the service), so
+the orender_create failure hint must point there instead of %APPDATA%.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 42d0172c91..4c2c7552b9 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -347,12 +347,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->renderer = orender_create(&cfg);
+     if (!p->renderer) {
+         /* liborender resolves the config per-OS (see
+-         * renderer/src/config.rs::default_config_path): %APPDATA% on
+-         * Windows, $XDG_CONFIG_HOME (or ~/.config) elsewhere. Match its
+-         * convention in the user-facing hint. */
++         * renderer/src/config.rs::default_config_path): %ProgramData% on
++         * Windows (machine-wide, shared with the service), $XDG_CONFIG_HOME
++         * (or ~/.config) elsewhere. Match its convention in the hint. */
+ #ifdef _WIN32
+         MP_ERR(da, "orender_create failed — set render.bridge_path in your "
+-                   "omniphony config (%%APPDATA%%\\omniphony\\config.yaml); "
++                   "omniphony config (%%ProgramData%%\\omniphony\\config.yaml); "
+                    "see stderr for the liborender error\n");
+ #else
+         MP_ERR(da, "orender_create failed — set render.bridge_path in your "

--- a/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/10] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/11] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/10] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/11] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/10] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/11] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/10] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/11] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/10] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/11] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/10] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/11] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/10] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/11] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/10] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/11] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/10] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/11] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/10] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/11] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Sat, 13 Jun 2026 11:10:05 +0200
+Subject: [PATCH 11/11] ad_orender: ProgramData config path in the Windows
+ bridge_path hint
+
+The renderer's Windows default config moved to %ProgramData%\omniphony\
+config.yaml (machine-wide, shared between user mode and the service), so
+the orender_create failure hint must point there instead of %APPDATA%.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 42d0172c91..4c2c7552b9 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -347,12 +347,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->renderer = orender_create(&cfg);
+     if (!p->renderer) {
+         /* liborender resolves the config per-OS (see
+-         * renderer/src/config.rs::default_config_path): %APPDATA% on
+-         * Windows, $XDG_CONFIG_HOME (or ~/.config) elsewhere. Match its
+-         * convention in the user-facing hint. */
++         * renderer/src/config.rs::default_config_path): %ProgramData% on
++         * Windows (machine-wide, shared with the service), $XDG_CONFIG_HOME
++         * (or ~/.config) elsewhere. Match its convention in the hint. */
+ #ifdef _WIN32
+         MP_ERR(da, "orender_create failed — set render.bridge_path in your "
+-                   "omniphony config (%%APPDATA%%\\omniphony\\config.yaml); "
++                   "omniphony config (%%ProgramData%%\\omniphony\\config.yaml); "
+                    "see stderr for the liborender error\n");
+ #else
+         MP_ERR(da, "orender_create failed — set render.bridge_path in your "

--- a/src/ad_orender.c
+++ b/src/ad_orender.c
@@ -347,12 +347,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
     p->renderer = orender_create(&cfg);
     if (!p->renderer) {
         /* liborender resolves the config per-OS (see
-         * renderer/src/config.rs::default_config_path): %APPDATA% on
-         * Windows, $XDG_CONFIG_HOME (or ~/.config) elsewhere. Match its
-         * convention in the user-facing hint. */
+         * renderer/src/config.rs::default_config_path): %ProgramData% on
+         * Windows (machine-wide, shared with the service), $XDG_CONFIG_HOME
+         * (or ~/.config) elsewhere. Match its convention in the hint. */
 #ifdef _WIN32
         MP_ERR(da, "orender_create failed — set render.bridge_path in your "
-                   "omniphony config (%%APPDATA%%\\omniphony\\config.yaml); "
+                   "omniphony config (%%ProgramData%%\\omniphony\\config.yaml); "
                    "see stderr for the liborender error\n");
 #else
         MP_ERR(da, "orender_create failed — set render.bridge_path in your "


### PR DESCRIPTION
Follow-up to Omniphony's machine-wide Windows config (`%ProgramData%\omniphony\config.yaml`, shared by user mode and the service).

Regenerated `patches/` and `patches-master/` from the fork (`orender` / `orender-master`, both pushed). Adds patch **0011** that updates the `orender_create` failure hint from `%APPDATA%` to `%ProgramData%`, and syncs `src/ad_orender.c`. The 10→11 renumber is the only change to the other patches.

CI (`build` v0.41 + `build-master`) validates the stack applies and compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)