### PR TITLE
docs: tell users to remove the legacy omniphony-overlay.lua

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,6 +416,11 @@ jobs:
             Windows. The live overlay is built into mpv itself — no script to
             install.
 
+            **Upgrading?** The overlay is now built in: delete any
+            `omniphony-overlay.lua` you previously copied into your mpv
+            `scripts/` directory. A leftover copy is harmless (it self-disables
+            on these PUC-Lua builds), but it is no longer needed.
+
             **NOT bundled:** the decoder bridge plugin
             (`omniphony_bridge.so` / `.dll`). Licensing constraints on the
             underlying codec mean users must obtain it themselves from

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ Studio still configures the overlay (trails, A/B tags, heatmap
 parameters) over OSC, into the renderer, whenever it is connected to the
 same liborender instance.
 
+> **Upgrading from the old Lua overlay?** Earlier versions shipped an
+> `omniphony-overlay.lua` you copied into your mpv `scripts/` directory.
+> It is no longer needed — you can delete it. On the released builds (PUC
+> Lua) it self-disables anyway (no LuaJIT FFI), so a leftover copy is
+> harmless; on a LuaJIT build it would just redundantly drive the same
+> overlay. Removing it keeps things tidy.
+
 #### Controlling the overlay from mpv
 
 The overlay client grabs **no keys by default** (mpv convention: you own


### PR DESCRIPTION
The overlay is built into mpv now. Adds an upgrade note (README + release body) that a previously-installed `omniphony-overlay.lua` can be deleted — harmless if left (it self-disables on PUC-Lua builds), just no longer needed.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)