### PR TITLE
chore(release): cut 0.4.0 (refresh patches + OMNIPHONY_REF→v0.4.0)

### DIFF
--- a/.github/scripts/mock-liborender.sh
+++ b/.github/scripts/mock-liborender.sh
@@ -33,6 +33,11 @@ void orender_destroy(OrenderRenderer *r);
 int orender_is_spatial(const OrenderRenderer *r);
 uint32_t orender_channel_count(const OrenderRenderer *r);
 uint32_t orender_channel_layout(const OrenderRenderer *r, uint8_t *out_labels, uint32_t cap);
+int orender_channel_mode(const OrenderRenderer *r);
+void orender_set_channel_mode(OrenderRenderer *r, int mode);
+int orender_object_count(const OrenderRenderer *r);
+int orender_dialnorm_db(const OrenderRenderer *r);
+uint32_t orender_bed_layout(const OrenderRenderer *r, uint8_t *out_labels, uint32_t cap);
 void orender_reset(OrenderRenderer *r);
 int orender_process(OrenderRenderer *r, const uint8_t *pkt, size_t pkt_len,
                     int64_t pts_us, float *out, size_t out_cap_samples,
@@ -42,6 +47,8 @@ uint32_t orender_version_minor(void);
 /* In-process spatial overlay (pulled by mpv's built-in overlay client). */
 uintptr_t orender_overlay_ass(uint32_t res_x, uint32_t res_y, uint8_t *out, uintptr_t cap);
 void orender_overlay_set_enabled(int enabled);
+void orender_overlay_set_rendering(int rendering);
+void orender_overlay_clear(void);
 int orender_overlay_toggle(void);
 int orender_overlay_toggle_labels(void);
 int orender_overlay_toggle_objects(void);
@@ -63,6 +70,11 @@ void orender_destroy(OrenderRenderer *r){(void)r;}
 int orender_is_spatial(const OrenderRenderer *r){(void)r;return 0;}
 uint32_t orender_channel_count(const OrenderRenderer *r){(void)r;return 0;}
 uint32_t orender_channel_layout(const OrenderRenderer *r,uint8_t *o,uint32_t c){(void)r;(void)o;(void)c;return 0;}
+int orender_channel_mode(const OrenderRenderer *r){(void)r;return 0;}
+void orender_set_channel_mode(OrenderRenderer *r,int m){(void)r;(void)m;}
+int orender_object_count(const OrenderRenderer *r){(void)r;return 0;}
+int orender_dialnorm_db(const OrenderRenderer *r){(void)r;return 0;}
+uint32_t orender_bed_layout(const OrenderRenderer *r,uint8_t *o,uint32_t c){(void)r;(void)o;(void)c;return 0;}
 void orender_reset(OrenderRenderer *r){(void)r;}
 int orender_process(OrenderRenderer *r,const uint8_t *p,size_t pl,int64_t t,
                     float *o,size_t oc,size_t *nf,uint32_t *nc,int64_t *op){
@@ -72,6 +84,8 @@ uint32_t orender_version_major(void){return 0;}
 uint32_t orender_version_minor(void){return 1;}
 uintptr_t orender_overlay_ass(uint32_t x,uint32_t y,uint8_t *o,uintptr_t c){(void)x;(void)y;(void)o;(void)c;return 0;}
 void orender_overlay_set_enabled(int e){(void)e;}
+void orender_overlay_set_rendering(int x){(void)x;}
+void orender_overlay_clear(void){}
 int orender_overlay_toggle(void){return 0;}
 int orender_overlay_toggle_labels(void){return 0;}
 int orender_overlay_toggle_objects(void){return 0;}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
   # construction, and removes the stale-prebuilt skew that made mpv silently
   # ship an old liborender (config parsed differently → default room). Bump
   # this one line on each release.
-  OMNIPHONY_REF: v0.3.3
+  OMNIPHONY_REF: v0.4.0
 
 jobs:
   build-linux:

--- a/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/11] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/17] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/11] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/17] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/11] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/17] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/11] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/17] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/11] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/17] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/11] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/17] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/11] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/17] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/11] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/17] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/11] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/17] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/11] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/17] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 13 Jun 2026 11:10:05 +0200
-Subject: [PATCH 11/11] ad_orender: ProgramData config path in the Windows
+Subject: [PATCH 11/17] ad_orender: ProgramData config path in the Windows
  bridge_path hint
 
 The renderer's Windows default config moved to %ProgramData%\omniphony\

--- a/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
+++ b/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
@@ -1,0 +1,244 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Sun, 14 Jun 2026 14:28:27 +0200
+Subject: [PATCH 12/17] ad_orender: host channel-mode fallback to the native
+ decoder
+
+Add --ad-orender-channel-mode (auto/host/direct/virtual) and, in host mode on a
+non-object stream, hand the track back to mpv's native decoder instead of
+rendering it through orender:
+
+- ad_orender probes spatial-vs-plain on the first packet; in host mode on a
+  non-object stream it sets want_fallback and stops consuming/emitting (emitting
+  silence would mask the empty output the wrapper polls). It also declines when
+  the renderer reports no output layout, rather than dropping every frame
+  (which froze playback).
+- New decoder control ADCTRL_CHECK_FALLBACK; f_decoder_wrapper polls it when the
+  orender decoder yields no frame and re-selects the native audio decoder
+  (orender_disabled), so the swap is clean and the track keeps playing.
+- The chosen mode is pushed to the engine via orender_set_channel_mode so the
+  option overrides the shared config for this invocation.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c   | 71 ++++++++++++++++++++++++++++++++++---
+ filters/f_decoder_wrapper.c | 30 ++++++++++++++--
+ filters/f_decoder_wrapper.h |  5 +++
+ 3 files changed, 99 insertions(+), 7 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 4c2c7552b9..4eef87b7ed 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -26,6 +26,7 @@
+ #include "audio/chmap.h"
+ #include "audio/format.h"
+ #include "common/codecs.h"
++#include "common/common.h"
+ #include "common/msg.h"
+ #include "demux/packet.h"
+ #include "demux/stheader.h"
+@@ -49,6 +50,7 @@ struct ad_orender_params {
+     int osc_rx_port;            // incoming control port  (0 = config/default 9000)
+     char *osc_bind;             // listener bind address (else config/default)
+     char *osc_monitor_target;   // monitoring host (else config/default)
++    int channel_mode_idx;       // non-object render override: 0=auto 1=host 2=direct 3=virtual
+ };
+ 
+ const struct m_sub_options ad_orender_conf = {
+@@ -60,6 +62,12 @@ const struct m_sub_options ad_orender_conf = {
+         {"osc-rx-port", OPT_INT(osc_rx_port), M_RANGE(0, 65535)},
+         {"osc-bind", OPT_STRING(osc_bind)},
+         {"osc-monitor-target", OPT_STRING(osc_monitor_target)},
++        /* How to render channel-based (non-object) content. Empty = follow the
++         * shared config's render.channel_render_mode. "host" hands the track
++         * back to mpv's native decoder; "direct"/"virtual" render it via
++         * orender. */
++        {"channel-mode", OPT_CHOICE(channel_mode_idx,
++            {"auto", 0}, {"host", 1}, {"direct", 2}, {"virtual", 3})},
+         {0}
+     },
+     .size = sizeof(struct ad_orender_params),
+@@ -91,6 +99,7 @@ struct priv {
+     int channels;
+     struct mp_chmap chmap;
+     bool checked_spatial;
++    bool want_fallback;   // decline → wrapper re-selects the native decoder
+     struct mp_decoder public;
+ };
+ 
+@@ -163,10 +172,32 @@ static void ad_orender_reset(struct mp_filter *da)
+     p->checked_spatial = false;
+ }
+ 
++/* Decoder control: lets the wrapper poll whether we want to be replaced by the
++ * native decoder (channel-mode=host on a plain stream, or no output layout). */
++static int ad_orender_control(struct mp_filter *da, enum dec_ctrl cmd, void *arg)
++{
++    struct priv *p = da->priv;
++    switch (cmd) {
++    case ADCTRL_CHECK_FALLBACK:
++        return p->want_fallback ? CONTROL_TRUE : CONTROL_FALSE;
++    default:
++        return CONTROL_UNKNOWN;
++    }
++}
++
+ static void ad_orender_process(struct mp_filter *da)
+ {
+     struct priv *p = da->priv;
+ 
++    // Already decided to hand the track back to mpv's native decoder: stop
++    // consuming and emitting. Producing silence frames here would mask the empty
++    // output that the wrapper polls to trigger the fallback (read_frame only
++    // checks ADCTRL_CHECK_FALLBACK when no frame is produced), so the decoder
++    // would otherwise stay selected and play silence. Leaving the packets unread
++    // keeps them available for ad_lavc after the wrapper re-selects it.
++    if (p->want_fallback)
++        return;
++
+     if (!mp_pin_can_transfer_data(da->ppins[1], da->ppins[0]))
+         return;
+ 
+@@ -218,13 +249,36 @@ static void ad_orender_process(struct mp_filter *da)
+     /* Resolve spatial-vs-plain + the output chmap on the first decoded packet. */
+     if (!p->checked_spatial) {
+         p->checked_spatial = true;
+-        if (orender_is_spatial(p->renderer) != 1) {
+-            MP_WARN(da, "no spatial objects detected; rendering the bed only "
+-                        "(decode this track without --ad=orender for the "
+-                        "standard downmix)\n");
++        bool spatial = orender_is_spatial(p->renderer) == 1;
++        int mode = orender_channel_mode(p->renderer); /* 0 host,1 direct,2 virtual */
++        if (!spatial && mode == 0) {
++            /* channel-mode=host on a plain multichannel stream: hand the track
++             * back to mpv's native decoder (the wrapper polls want_fallback and
++             * re-selects ad_lavc). This is the explicit "let mpv deal with it"
++             * path. */
++            MP_VERBOSE(da, "channel-mode=host on a non-object stream; "
++                           "handing back to the native decoder\n");
++            p->want_fallback = true;
++            goto done;
+         }
+-        if (!build_chmap(p))
++        if (!spatial) {
++            MP_VERBOSE(da, "no spatial objects; rendering channels via "
++                           "channel-mode=%s\n", mode == 1 ? "direct" : "virtual");
++        }
++        if (!build_chmap(p)) {
++            if (p->chmap.num == 0) {
++                /* The renderer reported no output channels (e.g. the speaker
++                 * layout could not be resolved). Rather than drop every frame —
++                 * which stalls the audio output and freezes playback — hand the
++                 * track back to mpv's native decoder. */
++                MP_WARN(da, "renderer reported no output layout; handing back "
++                            "to the native decoder (check the speaker layout in "
++                            "your omniphony config)\n");
++                p->want_fallback = true;
++                goto done;
++            }
+             MP_WARN(da, "output layout has speakers with no mpv mapping\n");
++        }
+     }
+ 
+     if (n_frames == 0)
+@@ -320,6 +374,7 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->codec = codec;
+     p->sample_rate = codec->samplerate;
+     p->public.f = da;
++    p->public.control = ad_orender_control;
+ 
+     struct ad_orender_params *opts =
+         mp_get_config_group(da, da->global, &ad_orender_conf);
+@@ -363,6 +418,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
+         return NULL;
+     }
+ 
++    /* Per-invocation override of the shared config's channel render mode.
++     * Option indices: 0=auto (follow config), 1=host, 2=direct, 3=virtual;
++     * the FFI mode codes are 0=host, 1=direct, 2=virtual. */
++    if (opts->channel_mode_idx > 0)
++        orender_set_channel_mode(p->renderer, opts->channel_mode_idx - 1);
++
+     p->channels = orender_channel_count(p->renderer);
+     codec->codec_desc = is_eac3 ? "eac3 (orender, spatial)"
+                                 : "truehd (orender, spatial)";
+diff --git a/filters/f_decoder_wrapper.c b/filters/f_decoder_wrapper.c
+index 4c56690e10..eff8f4a8de 100644
+--- a/filters/f_decoder_wrapper.c
++++ b/filters/f_decoder_wrapper.c
+@@ -191,6 +191,11 @@ struct priv {
+ 
+     int packets_without_output; // number packets sent without frame received
+ 
++#if HAVE_ORENDER
++    bool orender_active;   // the orender audio decoder is currently selected
++    bool orender_disabled; // force-skip orender on reinit (it declined this track)
++#endif
++
+     // Final PTS of previously decoded frame
+     double pts;
+ 
+@@ -460,7 +465,7 @@ static bool reinit_decoder(struct priv *p)
+         // (AF_FORMAT_FLOAT), so the native resampler / audio filter chain still
+         // applies. Gated on the explicit decoder name so default playback is
+         // unaffected.
+-        if (driver == &ad_lavc && p->codec->codec &&
++        if (!p->orender_disabled && driver == &ad_lavc && p->codec->codec &&
+             (strcmp(p->codec->codec, "truehd") == 0 ||
+              strcmp(p->codec->codec, "eac3") == 0) &&
+             decoder_list_has(user_list, "orender"))
+@@ -475,6 +480,7 @@ static bool reinit_decoder(struct priv *p)
+                 talloc_free(ol);
+             }
+         }
++        p->orender_active = (driver == &ad_orender);
+ #endif
+     }
+ 
+@@ -1063,8 +1069,28 @@ static void read_frame(struct priv *p)
+     p->reverse_queue_complete = false;
+ 
+     frame = mp_pin_out_read(p->decoder->f->pins[1]);
+-    if (!frame.type)
++    if (!frame.type) {
++#if HAVE_ORENDER
++        // The orender decoder can decline a track after probing the first
++        // packet (channel-mode=host on a plain stream, or no output layout):
++        // re-select the native decoder so playback continues instead of
++        // rendering nothing. The probe packet is dropped; the next packets feed
++        // ad_lavc.
++        if (p->orender_active && p->decoder && p->decoder->control &&
++            p->decoder->control(p->decoder->f, ADCTRL_CHECK_FALLBACK, NULL)
++                == CONTROL_TRUE)
++        {
++            MP_VERBOSE(p, "orender declined the track; falling back to the "
++                          "native audio decoder\n");
++            p->orender_disabled = true;
++            p->orender_active = false;
++            if (!decoder_wrapper_reinit(&p->public))
++                mp_filter_internal_mark_failed(p->decf);
++            mp_filter_internal_mark_progress(p->decf);
++        }
++#endif
+         return;
++    }
+ 
+     mp_mutex_lock(&p->cache_lock);
+     if (p->attached_picture && frame.type == MP_FRAME_VIDEO)
+diff --git a/filters/f_decoder_wrapper.h b/filters/f_decoder_wrapper.h
+index 53f336d85c..538a307efd 100644
+--- a/filters/f_decoder_wrapper.h
++++ b/filters/f_decoder_wrapper.h
+@@ -75,6 +75,11 @@ enum dec_ctrl {
+     // framedrop mode: 0=none, 1=standard, 2=hrseek
+     VDCTRL_SET_FRAMEDROP,
+     VDCTRL_CHECK_FORCED_EOF,
++    // Audio: decoder asks the wrapper to fall back to the native decoder (e.g.
++    // ad_orender on a non-object stream with channel-mode=host, or when the
++    // renderer cannot produce an output layout). Returns CONTROL_TRUE when a
++    // fallback is requested.
++    ADCTRL_CHECK_FALLBACK,
+ };
+ 
+ int mp_decoder_wrapper_control(struct mp_decoder_wrapper *d,

--- a/patches/0013-ad_orender-route-DTS-to-orender-too.patch
+++ b/patches/0013-ad_orender-route-DTS-to-orender-too.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Sun, 14 Jun 2026 16:37:06 +0200
+Subject: [PATCH 13/17] ad_orender: route DTS to orender too
+
+Add "dts" to the codec gate in f_decoder_wrapper (decoder selection) and
+ad_orender (create + add_decoders + codec_desc), so DTS tracks decode through
+liborender like TrueHD/E-AC3 when --ad=orender is requested. The bridge decodes
+DTS core / DTS-HD MA to a channel bed; DTS:X objects fall through to the host
+fallback in channel-mode=host.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c   | 14 ++++++++++----
+ filters/f_decoder_wrapper.c |  3 ++-
+ 2 files changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 4eef87b7ed..a5ca498659 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -356,9 +356,9 @@ static struct mp_decoder *create(struct mp_filter *parent,
+                                  const char *decoder)
+ {
+     if (!codec->codec ||
+-        (strcmp(codec->codec, "truehd") != 0 && strcmp(codec->codec, "eac3") != 0))
++        (strcmp(codec->codec, "truehd") != 0 && strcmp(codec->codec, "eac3") != 0 &&
++         strcmp(codec->codec, "dts") != 0))
+         return NULL;
+-    bool is_eac3 = strcmp(codec->codec, "eac3") == 0;
+ 
+     struct mp_filter *da = mp_filter_create(parent, &ad_orender_filter);
+     if (!da)
+@@ -425,8 +425,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
+         orender_set_channel_mode(p->renderer, opts->channel_mode_idx - 1);
+ 
+     p->channels = orender_channel_count(p->renderer);
+-    codec->codec_desc = is_eac3 ? "eac3 (orender, spatial)"
+-                                : "truehd (orender, spatial)";
++    if (strcmp(codec->codec, "eac3") == 0)
++        codec->codec_desc = "eac3 (orender, spatial)";
++    else if (strcmp(codec->codec, "dts") == 0)
++        codec->codec_desc = "dts (orender, spatial)";
++    else
++        codec->codec_desc = "truehd (orender, spatial)";
+ 
+     return &p->public;
+ }
+@@ -437,6 +441,8 @@ static void add_decoders(struct mp_decoder_list *list)
+                    "Spatial audio via liborender (VBAP object rendering)");
+     mp_add_decoder(list, "eac3", "orender",
+                    "Spatial audio via liborender (VBAP object rendering)");
++    mp_add_decoder(list, "dts", "orender",
++                   "Spatial audio via liborender (VBAP object rendering)");
+ }
+ 
+ const struct mp_decoder_fns ad_orender = {
+diff --git a/filters/f_decoder_wrapper.c b/filters/f_decoder_wrapper.c
+index eff8f4a8de..afa0e5d5d3 100644
+--- a/filters/f_decoder_wrapper.c
++++ b/filters/f_decoder_wrapper.c
+@@ -467,7 +467,8 @@ static bool reinit_decoder(struct priv *p)
+         // unaffected.
+         if (!p->orender_disabled && driver == &ad_lavc && p->codec->codec &&
+             (strcmp(p->codec->codec, "truehd") == 0 ||
+-             strcmp(p->codec->codec, "eac3") == 0) &&
++             strcmp(p->codec->codec, "eac3") == 0 ||
++             strcmp(p->codec->codec, "dts") == 0) &&
+             decoder_list_has(user_list, "orender"))
+         {
+             struct mp_decoder_list *ol =

--- a/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
+++ b/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
@@ -1,0 +1,111 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Mon, 15 Jun 2026 08:14:44 +0200
+Subject: [PATCH 14/17] ad_orender: render AC-3 through orender; fix
+ channel-mode option
+
+- Offer the orender decoder for the `ac3` codec (in addition to truehd,
+  eac3, dts). AC-3 is channel-based; the bridge already routes `ac3` to its
+  E-AC3 decoder (RawCodec::Eac3) and the engine renders it via the virtual
+  bed, so plain Dolby Digital tracks were the only ones falling back to
+  mpv's native decoder with no spatialization. Register it + codec_desc.
+- Update the `--ad-orender-channel-mode` option to the collapsed model:
+  auto | host | spatial, with `direct`/`virtual` kept as legacy aliases of
+  `spatial`. The option values (0=auto,1=host,2=spatial) map cleanly to the
+  FFI codes (0=host,1=spatial) via `value - 1`. Fix the now-stale comments
+  and the verbose log that still said "direct/virtual".
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 29 +++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index a5ca498659..96e5f6bb19 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -50,7 +50,7 @@ struct ad_orender_params {
+     int osc_rx_port;            // incoming control port  (0 = config/default 9000)
+     char *osc_bind;             // listener bind address (else config/default)
+     char *osc_monitor_target;   // monitoring host (else config/default)
+-    int channel_mode_idx;       // non-object render override: 0=auto 1=host 2=direct 3=virtual
++    int channel_mode_idx;       // non-object render override: 0=auto 1=host 2=spatial
+ };
+ 
+ const struct m_sub_options ad_orender_conf = {
+@@ -62,12 +62,12 @@ const struct m_sub_options ad_orender_conf = {
+         {"osc-rx-port", OPT_INT(osc_rx_port), M_RANGE(0, 65535)},
+         {"osc-bind", OPT_STRING(osc_bind)},
+         {"osc-monitor-target", OPT_STRING(osc_monitor_target)},
+-        /* How to render channel-based (non-object) content. Empty = follow the
+-         * shared config's render.channel_render_mode. "host" hands the track
+-         * back to mpv's native decoder; "direct"/"virtual" render it via
+-         * orender. */
++        /* How to render channel-based (non-object) content. "auto" = follow the
++         * shared config's render.channel_render_mode. "host" hands the track back
++         * to mpv's native decoder; "spatial" renders it through orender's virtual
++         * bed. "direct"/"virtual" are legacy aliases of "spatial". */
+         {"channel-mode", OPT_CHOICE(channel_mode_idx,
+-            {"auto", 0}, {"host", 1}, {"direct", 2}, {"virtual", 3})},
++            {"auto", 0}, {"host", 1}, {"spatial", 2}, {"direct", 2}, {"virtual", 2})},
+         {0}
+     },
+     .size = sizeof(struct ad_orender_params),
+@@ -250,7 +250,7 @@ static void ad_orender_process(struct mp_filter *da)
+     if (!p->checked_spatial) {
+         p->checked_spatial = true;
+         bool spatial = orender_is_spatial(p->renderer) == 1;
+-        int mode = orender_channel_mode(p->renderer); /* 0 host,1 direct,2 virtual */
++        int mode = orender_channel_mode(p->renderer); /* 0 host, 1 spatial */
+         if (!spatial && mode == 0) {
+             /* channel-mode=host on a plain multichannel stream: hand the track
+              * back to mpv's native decoder (the wrapper polls want_fallback and
+@@ -262,8 +262,8 @@ static void ad_orender_process(struct mp_filter *da)
+             goto done;
+         }
+         if (!spatial) {
+-            MP_VERBOSE(da, "no spatial objects; rendering channels via "
+-                           "channel-mode=%s\n", mode == 1 ? "direct" : "virtual");
++            MP_VERBOSE(da, "no spatial objects; rendering channels through the "
++                           "virtual bed (channel-mode=spatial)\n");
+         }
+         if (!build_chmap(p)) {
+             if (p->chmap.num == 0) {
+@@ -357,7 +357,7 @@ static struct mp_decoder *create(struct mp_filter *parent,
+ {
+     if (!codec->codec ||
+         (strcmp(codec->codec, "truehd") != 0 && strcmp(codec->codec, "eac3") != 0 &&
+-         strcmp(codec->codec, "dts") != 0))
++         strcmp(codec->codec, "ac3") != 0 && strcmp(codec->codec, "dts") != 0))
+         return NULL;
+ 
+     struct mp_filter *da = mp_filter_create(parent, &ad_orender_filter);
+@@ -419,14 +419,17 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     }
+ 
+     /* Per-invocation override of the shared config's channel render mode.
+-     * Option indices: 0=auto (follow config), 1=host, 2=direct, 3=virtual;
+-     * the FFI mode codes are 0=host, 1=direct, 2=virtual. */
++     * Option values: 0=auto (follow config), 1=host, 2=spatial (direct/virtual
++     * are legacy aliases of spatial). FFI mode codes: 0=host, 1=spatial — so
++     * `value - 1` maps host(1)→0 and spatial(2)→1. */
+     if (opts->channel_mode_idx > 0)
+         orender_set_channel_mode(p->renderer, opts->channel_mode_idx - 1);
+ 
+     p->channels = orender_channel_count(p->renderer);
+     if (strcmp(codec->codec, "eac3") == 0)
+         codec->codec_desc = "eac3 (orender, spatial)";
++    else if (strcmp(codec->codec, "ac3") == 0)
++        codec->codec_desc = "ac3 (orender, spatial)";
+     else if (strcmp(codec->codec, "dts") == 0)
+         codec->codec_desc = "dts (orender, spatial)";
+     else
+@@ -441,6 +444,8 @@ static void add_decoders(struct mp_decoder_list *list)
+                    "Spatial audio via liborender (VBAP object rendering)");
+     mp_add_decoder(list, "eac3", "orender",
+                    "Spatial audio via liborender (VBAP object rendering)");
++    mp_add_decoder(list, "ac3", "orender",
++                   "Spatial audio via liborender (VBAP object rendering)");
+     mp_add_decoder(list, "dts", "orender",
+                    "Spatial audio via liborender (VBAP object rendering)");
+ }

--- a/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
+++ b/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
@@ -1,0 +1,534 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 16 Jun 2026 08:25:41 +0200
+Subject: [PATCH 15/17] feat(ad_orender): keep the engine alive in host mode;
+ live spatial<->host
+
+ad_orender is now the persistent decoder for the supported codecs and
+never declines. It owns the orender engine for the whole track (the OSC
+listener and the Studio connection stay alive) and routes each packet on
+the engine's live channel_render_mode:
+- spatial: decode + VBAP-render through the engine;
+- host: delegate to a native child decoder and forward its frames.
+
+Toggling "Spatialize 2D sources" in Studio flips the mode over OSC, so the
+switch applies live in both directions with no restart and no polling.
+
+- Add --ad-orender-host-decoder=lavc|spdif to choose the host decoder.
+- Clear the spatial overlay on host entry (nothing is spatialized).
+- Add ac3 to the orender decoder-swap gate.
+- Remove the now-dead wrapper fallback path (orender_active/
+  orender_disabled, ADCTRL_CHECK_FALLBACK); keep the ac3 gate entry.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c   | 305 ++++++++++++++++++++++++------------
+ filters/f_decoder_wrapper.c |  32 +---
+ filters/f_decoder_wrapper.h |   5 -
+ 3 files changed, 213 insertions(+), 129 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 96e5f6bb19..313a947f96 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -2,19 +2,26 @@
+  * ad_orender.c — mpv audio decoder that renders spatial audio through liborender.
+  *
+  * Companion to ad_lavc/ad_spdif: when the user opts in with `--ad=orender` on a
+- * supported stream, decode + VBAP-render the spatial objects to N-channel
+- * float PCM via liborender (orender_*), instead of letting FFmpeg downmix.
++ * supported stream, decode + VBAP-render the spatial objects to N-channel float
++ * PCM via liborender (orender_*), instead of letting FFmpeg downmix.
+  *
+- * Modeled on ad_spdif.c (a non-lavc mp_filter decoder). liborender does the
+- * decode (via a runtime bridge plugin) and the spatial render; this file only
+- * shuttles packets in and aframes out through the filter pin protocol.
++ * Unlike the earlier design, ad_orender does NOT hand the track back to the
++ * decoder wrapper in host mode. It stays selected for the whole track and owns
++ * the orender engine the whole time, so the engine's OSC listener — and thus the
++ * Studio connection — stays alive and keeps receiving the live
++ * `channel_render_mode` switch. Each packet is routed on that live mode:
+  *
+- * Phase 4: opt-in only (so default playback is untouched). The decoder
+- * bridge and speaker layout come from the shared omniphony config YAML
+- * (render.bridge_path) — the SAME config the orender CLI + studio use
+- * (~/.config/omniphony/config.yaml), resolved by liborender when the config
+- * path is NULL. The `--ad-orender-*` options, the is_spatial→ad_lavc fallback,
+- * and custom chmaps are Phase 5.
++ *   - spatial : decode + VBAP-render through the engine (objects, or the virtual
++ *               bed for plain channel content);
++ *   - host    : delegate to a native child decoder (ad_lavc → PCM, or ad_spdif →
++ *               bitstream passthrough; chosen by --ad-orender-host-decoder) and
++ *               forward its frames untouched.
++ *
++ * Toggling "Spatialize 2D sources" in Studio flips the engine's mode over OSC,
++ * so the switch is applied live, in both directions, with no mpv restart and no
++ * polling — the engine never leaves, never yields the OSC port to the standby
++ * renderer. The bridge and speaker layout come from the shared omniphony config
++ * YAML (render.bridge_path), resolved by liborender when the config path is NULL.
+  */
+ 
+ #include <stdbool.h>
+@@ -50,7 +57,8 @@ struct ad_orender_params {
+     int osc_rx_port;            // incoming control port  (0 = config/default 9000)
+     char *osc_bind;             // listener bind address (else config/default)
+     char *osc_monitor_target;   // monitoring host (else config/default)
+-    int channel_mode_idx;       // non-object render override: 0=auto 1=host 2=spatial
++    int channel_mode_idx;       // initial render override: 0=auto 1=host 2=spatial
++    int host_decoder_idx;       // host-mode native decoder: 0=lavc 1=spdif
+ };
+ 
+ const struct m_sub_options ad_orender_conf = {
+@@ -62,12 +70,17 @@ const struct m_sub_options ad_orender_conf = {
+         {"osc-rx-port", OPT_INT(osc_rx_port), M_RANGE(0, 65535)},
+         {"osc-bind", OPT_STRING(osc_bind)},
+         {"osc-monitor-target", OPT_STRING(osc_monitor_target)},
+-        /* How to render channel-based (non-object) content. "auto" = follow the
+-         * shared config's render.channel_render_mode. "host" hands the track back
+-         * to mpv's native decoder; "spatial" renders it through orender's virtual
+-         * bed. "direct"/"virtual" are legacy aliases of "spatial". */
++        /* Initial render mode for channel-based (non-object) content. "auto" =
++         * follow the shared config's render.channel_render_mode. "host" decodes
++         * natively (see host-decoder); "spatial" renders through orender's
++         * virtual bed. "direct"/"virtual" are legacy aliases of "spatial". The
++         * live mode is then driven by Studio over OSC. */
+         {"channel-mode", OPT_CHOICE(channel_mode_idx,
+             {"auto", 0}, {"host", 1}, {"spatial", 2}, {"direct", 2}, {"virtual", 2})},
++        /* Which native decoder to use in host mode: "lavc" decodes to PCM (mpv's
++         * audio chain applies — the default), "spdif" passes the compressed
++         * bitstream through to an AV receiver. */
++        {"host-decoder", OPT_CHOICE(host_decoder_idx, {"lavc", 0}, {"spdif", 1})},
+         {0}
+     },
+     .size = sizeof(struct ad_orender_params),
+@@ -81,6 +94,9 @@ const struct m_sub_options ad_orender_conf = {
+ /* An empty option string means "unset" → pass NULL to the FFI. */
+ static const char *nz(const char *s) { return (s && s[0]) ? s : NULL; }
+ 
++enum { HOST_DEC_LAVC = 0, HOST_DEC_SPDIF = 1 };
++enum { PATH_NONE = -1, PATH_HOST = 0, PATH_SPATIAL = 1 };
++
+ /* liborender channel labels — mirror bridge_api::RChannelLabel. cbindgen runs
+  * with parse_deps=false, so orender.h does not emit this enum; keep in sync. */
+ enum {
+@@ -98,8 +114,11 @@ struct priv {
+     int sample_rate;
+     int channels;
+     struct mp_chmap chmap;
+-    bool checked_spatial;
+-    bool want_fallback;   // decline → wrapper re-selects the native decoder
++    bool checked_spatial;       // built the output chmap for the spatial path
++    bool force_host;            // engine unusable (no layout / create failed): always native
++    int host_decoder_idx;       // HOST_DEC_LAVC (PCM) or HOST_DEC_SPDIF (passthrough)
++    struct mp_decoder *native;  // lazily-created native child decoder for host mode
++    int active_path;            // PATH_* of the last packet, for clean transitions
+     struct mp_decoder public;
+ };
+ 
+@@ -155,49 +174,84 @@ static bool build_chmap(struct priv *p)
+     return ok;
+ }
+ 
+-static void ad_orender_destroy(struct mp_filter *da)
++/* Try each entry in `sel` with `fns->create`, stopping at the first success. */
++static bool try_create_child(struct mp_filter *da, struct priv *p,
++                             const struct mp_decoder_fns *fns,
++                             struct mp_decoder_list *sel)
+ {
+-    struct priv *p = da->priv;
+-    if (p->renderer) {
+-        orender_destroy(p->renderer);
+-        p->renderer = NULL;
++    for (int i = 0; i < sel->num_entries; i++) {
++        p->native = fns->create(da, p->codec, sel->entries[i].decoder);
++        if (p->native) {
++            MP_VERBOSE(da, "host-mode native decoder: %s\n", sel->entries[i].decoder);
++            return true;
++        }
+     }
++    return false;
+ }
+ 
+-static void ad_orender_reset(struct mp_filter *da)
++/* Lazily create the native child decoder for host mode, picking the right driver
++ * + decoder for the codec via mpv's normal selection (so e.g. dts → "dca"). With
++ * host-decoder=spdif, request bitstream passthrough for this codec; if that is
++ * not available, fall back to lavc rather than leaving the track undecodable. */
++static bool ensure_native_child(struct mp_filter *da, struct priv *p)
+ {
+-    struct priv *p = da->priv;
+-    if (p->renderer)
+-        orender_reset(p->renderer);
+-    p->checked_spatial = false;
+-}
++    if (p->native)
++        return true;
++
++    if (p->host_decoder_idx == HOST_DEC_SPDIF) {
++        /* select_spdif_codec only enables passthrough for codecs listed in its
++         * `pref`; pass this codec so the explicit choice takes effect. */
++        struct mp_decoder_list *sel = select_spdif_codec(p->codec->codec, p->codec->codec);
++        bool ok = try_create_child(da, p, &ad_spdif, sel);
++        talloc_free(sel);
++        if (!ok)
++            MP_WARN(da, "spdif passthrough unavailable for %s; using lavc\n",
++                    p->codec->codec);
++    }
+ 
+-/* Decoder control: lets the wrapper poll whether we want to be replaced by the
+- * native decoder (channel-mode=host on a plain stream, or no output layout). */
+-static int ad_orender_control(struct mp_filter *da, enum dec_ctrl cmd, void *arg)
+-{
+-    struct priv *p = da->priv;
+-    switch (cmd) {
+-    case ADCTRL_CHECK_FALLBACK:
+-        return p->want_fallback ? CONTROL_TRUE : CONTROL_FALSE;
+-    default:
+-        return CONTROL_UNKNOWN;
++    if (!p->native) {
++        struct mp_decoder_list *all = talloc_zero(NULL, struct mp_decoder_list);
++        ad_lavc.add_decoders(all);
++        struct mp_decoder_list *sel = mp_select_decoders(p->log, all, p->codec->codec, NULL);
++        talloc_free(all);
++        try_create_child(da, p, &ad_lavc, sel);
++        talloc_free(sel);
+     }
++
++    if (!p->native) {
++        MP_ERR(da, "could not create a host-mode native decoder for %s\n",
++               p->codec->codec);
++        return false;
++    }
++    return true;
+ }
+ 
+-static void ad_orender_process(struct mp_filter *da)
++/* Host mode: pump the native child — forward packets in, decoded frames out. */
++static void process_host(struct mp_filter *da, struct priv *p)
+ {
+-    struct priv *p = da->priv;
+-
+-    // Already decided to hand the track back to mpv's native decoder: stop
+-    // consuming and emitting. Producing silence frames here would mask the empty
+-    // output that the wrapper polls to trigger the fallback (read_frame only
+-    // checks ADCTRL_CHECK_FALLBACK when no frame is produced), so the decoder
+-    // would otherwise stay selected and play silence. Leaving the packets unread
+-    // keeps them available for ad_lavc after the wrapper re-selects it.
+-    if (p->want_fallback)
++    if (!ensure_native_child(da, p)) {
++        mp_filter_internal_mark_failed(da);
+         return;
++    }
+ 
++    struct mp_pin *child_in = p->native->f->pins[0];
++    struct mp_pin *child_out = p->native->f->pins[1];
++
++    // Drain decoded frames to our output (and forward EOF transparently).
++    if (mp_pin_can_transfer_data(da->ppins[1], child_out)) {
++        struct mp_frame frame = mp_pin_out_read(child_out);
++        mp_pin_in_write(da->ppins[1], frame);
++    }
++    // Feed input packets to the child.
++    if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
++        struct mp_frame frame = mp_pin_out_read(da->ppins[0]);
++        mp_pin_in_write(child_in, frame);
++    }
++}
++
++/* Spatial mode: decode + VBAP-render through the engine. */
++static void process_spatial(struct mp_filter *da, struct priv *p)
++{
+     if (!mp_pin_can_transfer_data(da->ppins[1], da->ppins[0]))
+         return;
+ 
+@@ -246,44 +300,30 @@ static void ad_orender_process(struct mp_filter *da)
+         goto done;
+     }
+ 
+-    /* Resolve spatial-vs-plain + the output chmap on the first decoded packet. */
++    if (n_frames == 0)
++        goto done;   /* packet consumed; no output yet (need more data) */
++
++    /* Resolve the output chmap on the first *decoded* frame. Deferred until
++     * n_frames > 0: the layout is only meaningful once the bridge has decoded a
++     * frame (AC-3/DTS need several packets to acquire sync). */
+     if (!p->checked_spatial) {
+         p->checked_spatial = true;
+-        bool spatial = orender_is_spatial(p->renderer) == 1;
+-        int mode = orender_channel_mode(p->renderer); /* 0 host, 1 spatial */
+-        if (!spatial && mode == 0) {
+-            /* channel-mode=host on a plain multichannel stream: hand the track
+-             * back to mpv's native decoder (the wrapper polls want_fallback and
+-             * re-selects ad_lavc). This is the explicit "let mpv deal with it"
+-             * path. */
+-            MP_VERBOSE(da, "channel-mode=host on a non-object stream; "
+-                           "handing back to the native decoder\n");
+-            p->want_fallback = true;
+-            goto done;
+-        }
+-        if (!spatial) {
+-            MP_VERBOSE(da, "no spatial objects; rendering channels through the "
+-                           "virtual bed (channel-mode=spatial)\n");
+-        }
+         if (!build_chmap(p)) {
+             if (p->chmap.num == 0) {
+                 /* The renderer reported no output channels (e.g. the speaker
+-                 * layout could not be resolved). Rather than drop every frame —
+-                 * which stalls the audio output and freezes playback — hand the
+-                 * track back to mpv's native decoder. */
+-                MP_WARN(da, "renderer reported no output layout; handing back "
+-                            "to the native decoder (check the speaker layout in "
+-                            "your omniphony config)\n");
+-                p->want_fallback = true;
++                 * layout could not be resolved). Spatial rendering is impossible,
++                 * so route to the native host decoder for the rest of the track
++                 * rather than dropping every frame (which would freeze audio). */
++                MP_WARN(da, "renderer reported no output layout; decoding "
++                            "natively instead (check the speaker layout in your "
++                            "omniphony config)\n");
++                p->force_host = true;
+                 goto done;
+             }
+             MP_WARN(da, "output layout has speakers with no mpv mapping\n");
+         }
+     }
+ 
+-    if (n_frames == 0)
+-        goto done;   /* packet consumed; no output yet (need more data) */
+-
+     /* Live output-mode switches change the channel count mid-stream: rebuild
+      * the chmap so the frame below is allocated for what we actually copy —
+      * mpv's filter chain renegotiates downstream formats per frame. Without
+@@ -340,6 +380,74 @@ done:
+         mp_pin_in_write(da->ppins[1], MAKE_FRAME(MP_FRAME_AUDIO, out));
+     } else if (failed) {
+         mp_filter_internal_mark_failed(da);
++    } else {
++        // No output frame this pass: re-run so the graph stays active. The bridge
++        // needs several packets to acquire sync for some codecs (AC-3/DTS) before
++        // the first decoded frame, so early packets legitimately yield zero
++        // frames; re-running requests the next packet. Without this mpv never
++        // gets a first frame, the audio output is never created, and playback
++        // freezes on the first video frame with no sound. (Also covers the
++        // re-sync after a host→spatial switch, where the bridge was just reset.)
++        mp_filter_internal_mark_progress(da);
++    }
++}
++
++static void ad_orender_process(struct mp_filter *da)
++{
++    struct priv *p = da->priv;
++
++    /* Route on the engine's live channel_render_mode (0 host, 1 spatial), which
++     * Studio flips over OSC. Reading it per packet is a cheap in-memory call, not
++     * a poll. `force_host` (engine unusable) pins host. */
++    int mode = p->renderer ? orender_channel_mode(p->renderer) : 0;
++    bool host = p->force_host || mode != 1;
++    int path = host ? PATH_HOST : PATH_SPATIAL;
++
++    /* On a mode flip, flush stale state on the side we switch *to* so it starts
++     * clean: the engine's bridge re-acquires sync (it wasn't fed during host),
++     * and the native child drops any partial state from a previous host stint. */
++    if (path != p->active_path) {
++        if (path == PATH_SPATIAL) {
++            if (p->renderer)
++                orender_reset(p->renderer);
++            p->checked_spatial = false;
++        } else {
++            if (p->native && p->native->f)
++                mp_filter_reset(p->native->f);
++            /* Stop showing the spatial overlay while we decode natively: nothing
++             * is being spatialized, so clear the scene immediately rather than
++             * leaving the last frame to linger until the trails decay. The user's
++             * overlay on/off preference is preserved; spatial mode repopulates it. */
++            orender_overlay_clear();
++        }
++        p->active_path = path;
++    }
++
++    if (host)
++        process_host(da, p);
++    else
++        process_spatial(da, p);
++}
++
++static void ad_orender_reset(struct mp_filter *da)
++{
++    struct priv *p = da->priv;
++    if (p->renderer)
++        orender_reset(p->renderer);
++    if (p->native && p->native->f)
++        mp_filter_reset(p->native->f);
++    p->checked_spatial = false;
++    p->active_path = PATH_NONE;
++}
++
++static void ad_orender_destroy(struct mp_filter *da)
++{
++    struct priv *p = da->priv;
++    /* The native child is a talloc child of `da` and is freed with it; the
++     * engine is an FFI handle we must release explicitly. */
++    if (p->renderer) {
++        orender_destroy(p->renderer);
++        p->renderer = NULL;
+     }
+ }
+ 
+@@ -373,11 +481,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->log = da->log;
+     p->codec = codec;
+     p->sample_rate = codec->samplerate;
++    p->active_path = PATH_NONE;
+     p->public.f = da;
+-    p->public.control = ad_orender_control;
+ 
+     struct ad_orender_params *opts =
+         mp_get_config_group(da, da->global, &ad_orender_conf);
++    p->host_decoder_idx = opts->host_decoder_idx;
+ 
+     OrenderConfig cfg = {
+         .sample_rate         = p->sample_rate,
+@@ -401,39 +510,41 @@ static struct mp_decoder *create(struct mp_filter *parent,
+ 
+     p->renderer = orender_create(&cfg);
+     if (!p->renderer) {
+-        /* liborender resolves the config per-OS (see
+-         * renderer/src/config.rs::default_config_path): %ProgramData% on
+-         * Windows (machine-wide, shared with the service), $XDG_CONFIG_HOME
+-         * (or ~/.config) elsewhere. Match its convention in the hint. */
++        /* The engine could not start (e.g. a bad render.bridge_path). Rather than
++         * leave the track with no decoder at all, stay selected and decode
++         * natively for the whole session (host). Spatial is impossible until the
++         * config is fixed and mpv restarted, but audio still plays. */
+ #ifdef _WIN32
+-        MP_ERR(da, "orender_create failed — set render.bridge_path in your "
+-                   "omniphony config (%%ProgramData%%\\omniphony\\config.yaml); "
+-                   "see stderr for the liborender error\n");
++        MP_ERR(da, "orender_create failed — decoding natively. Set "
++                   "render.bridge_path in your omniphony config "
++                   "(%%ProgramData%%\\omniphony\\config.yaml); see stderr.\n");
+ #else
+-        MP_ERR(da, "orender_create failed — set render.bridge_path in your "
+-                   "omniphony config (~/.config/omniphony/config.yaml); see "
+-                   "stderr for the liborender error\n");
++        MP_ERR(da, "orender_create failed — decoding natively. Set "
++                   "render.bridge_path in your omniphony config "
++                   "(~/.config/omniphony/config.yaml); see stderr.\n");
+ #endif
+-        talloc_free(da);
+-        return NULL;
++        p->force_host = true;
+     }
+ 
+-    /* Per-invocation override of the shared config's channel render mode.
++    /* Per-invocation override of the shared config's initial channel render mode.
+      * Option values: 0=auto (follow config), 1=host, 2=spatial (direct/virtual
+      * are legacy aliases of spatial). FFI mode codes: 0=host, 1=spatial — so
+-     * `value - 1` maps host(1)→0 and spatial(2)→1. */
+-    if (opts->channel_mode_idx > 0)
++     * `value - 1` maps host(1)→0 and spatial(2)→1. The live mode is then driven
++     * by Studio over OSC. */
++    if (p->renderer && opts->channel_mode_idx > 0)
+         orender_set_channel_mode(p->renderer, opts->channel_mode_idx - 1);
+ 
+-    p->channels = orender_channel_count(p->renderer);
++    if (p->renderer)
++        p->channels = orender_channel_count(p->renderer);
++
+     if (strcmp(codec->codec, "eac3") == 0)
+-        codec->codec_desc = "eac3 (orender, spatial)";
++        codec->codec_desc = "eac3 (orender)";
+     else if (strcmp(codec->codec, "ac3") == 0)
+-        codec->codec_desc = "ac3 (orender, spatial)";
++        codec->codec_desc = "ac3 (orender)";
+     else if (strcmp(codec->codec, "dts") == 0)
+-        codec->codec_desc = "dts (orender, spatial)";
++        codec->codec_desc = "dts (orender)";
+     else
+-        codec->codec_desc = "truehd (orender, spatial)";
++        codec->codec_desc = "truehd (orender)";
+ 
+     return &p->public;
+ }
+diff --git a/filters/f_decoder_wrapper.c b/filters/f_decoder_wrapper.c
+index afa0e5d5d3..576051601f 100644
+--- a/filters/f_decoder_wrapper.c
++++ b/filters/f_decoder_wrapper.c
+@@ -191,11 +191,6 @@ struct priv {
+ 
+     int packets_without_output; // number packets sent without frame received
+ 
+-#if HAVE_ORENDER
+-    bool orender_active;   // the orender audio decoder is currently selected
+-    bool orender_disabled; // force-skip orender on reinit (it declined this track)
+-#endif
+-
+     // Final PTS of previously decoded frame
+     double pts;
+ 
+@@ -464,10 +459,13 @@ static bool reinit_decoder(struct priv *p)
+         // `--ad=orender`. Unlike ad_spdif this outputs normal float PCM
+         // (AF_FORMAT_FLOAT), so the native resampler / audio filter chain still
+         // applies. Gated on the explicit decoder name so default playback is
+-        // unaffected.
+-        if (!p->orender_disabled && driver == &ad_lavc && p->codec->codec &&
++        // unaffected. ad_orender stays selected for the whole track and decodes
++        // host-mode content via an internal native child, so the wrapper never
++        // needs to swap it back out.
++        if (driver == &ad_lavc && p->codec->codec &&
+             (strcmp(p->codec->codec, "truehd") == 0 ||
+              strcmp(p->codec->codec, "eac3") == 0 ||
++             strcmp(p->codec->codec, "ac3") == 0 ||
+              strcmp(p->codec->codec, "dts") == 0) &&
+             decoder_list_has(user_list, "orender"))
+         {
+@@ -481,7 +479,6 @@ static bool reinit_decoder(struct priv *p)
+                 talloc_free(ol);
+             }
+         }
+-        p->orender_active = (driver == &ad_orender);
+ #endif
+     }
+ 
+@@ -1071,25 +1068,6 @@ static void read_frame(struct priv *p)
+ 
+     frame = mp_pin_out_read(p->decoder->f->pins[1]);
+     if (!frame.type) {
+-#if HAVE_ORENDER
+-        // The orender decoder can decline a track after probing the first
+-        // packet (channel-mode=host on a plain stream, or no output layout):
+-        // re-select the native decoder so playback continues instead of
+-        // rendering nothing. The probe packet is dropped; the next packets feed
+-        // ad_lavc.
+-        if (p->orender_active && p->decoder && p->decoder->control &&
+-            p->decoder->control(p->decoder->f, ADCTRL_CHECK_FALLBACK, NULL)
+-                == CONTROL_TRUE)
+-        {
+-            MP_VERBOSE(p, "orender declined the track; falling back to the "
+-                          "native audio decoder\n");
+-            p->orender_disabled = true;
+-            p->orender_active = false;
+-            if (!decoder_wrapper_reinit(&p->public))
+-                mp_filter_internal_mark_failed(p->decf);
+-            mp_filter_internal_mark_progress(p->decf);
+-        }
+-#endif
+         return;
+     }
+ 
+diff --git a/filters/f_decoder_wrapper.h b/filters/f_decoder_wrapper.h
+index 538a307efd..53f336d85c 100644
+--- a/filters/f_decoder_wrapper.h
++++ b/filters/f_decoder_wrapper.h
+@@ -75,11 +75,6 @@ enum dec_ctrl {
+     // framedrop mode: 0=none, 1=standard, 2=hrseek
+     VDCTRL_SET_FRAMEDROP,
+     VDCTRL_CHECK_FORCED_EOF,
+-    // Audio: decoder asks the wrapper to fall back to the native decoder (e.g.
+-    // ad_orender on a non-object stream with channel-mode=host, or when the
+-    // renderer cannot produce an output layout). Returns CONTROL_TRUE when a
+-    // fallback is requested.
+-    ADCTRL_CHECK_FALLBACK,
+ };
+ 
+ int mp_decoder_wrapper_control(struct mp_decoder_wrapper *d,

--- a/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
+++ b/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 16 Jun 2026 08:35:47 +0200
+Subject: [PATCH 16/17] feat(ad_orender): hide the spatial overlay in host mode
+
+When routing channel audio to the native host decoder, suppress the whole
+spatial overlay (wireframe cube included) via orender_overlay_set_rendering(0)
+on host entry, and restore it on spatial entry. Also set the initial state in
+create() to the starting mode so the cube does not flash before the first
+packet. The user's overlay on/off preference is preserved.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 313a947f96..1bf16c9947 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -411,13 +411,15 @@ static void ad_orender_process(struct mp_filter *da)
+             if (p->renderer)
+                 orender_reset(p->renderer);
+             p->checked_spatial = false;
++            orender_overlay_set_rendering(1);  // show the spatial overlay again
+         } else {
+             if (p->native && p->native->f)
+                 mp_filter_reset(p->native->f);
+-            /* Stop showing the spatial overlay while we decode natively: nothing
+-             * is being spatialized, so clear the scene immediately rather than
+-             * leaving the last frame to linger until the trails decay. The user's
+-             * overlay on/off preference is preserved; spatial mode repopulates it. */
++            /* Hide the whole spatial overlay (wireframe cube included) while we
++             * decode natively — nothing is being spatialized — and drop the stale
++             * scene so it does not linger. The user's overlay on/off preference is
++             * preserved; spatial mode repopulates it. */
++            orender_overlay_set_rendering(0);
+             orender_overlay_clear();
+         }
+         p->active_path = path;
+@@ -537,6 +539,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     if (p->renderer)
+         p->channels = orender_channel_count(p->renderer);
+ 
++    /* Match the overlay's initial visibility to the starting mode, so it does not
++     * flash the wireframe cube before the first packet picks the path. */
++    bool start_host = p->force_host ||
++                      !p->renderer || orender_channel_mode(p->renderer) != 1;
++    orender_overlay_set_rendering(start_host ? 0 : 1);
++
+     if (strcmp(codec->codec, "eac3") == 0)
+         codec->codec_desc = "eac3 (orender)";
+     else if (strcmp(codec->codec, "ac3") == 0)

--- a/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
+++ b/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
@@ -1,0 +1,211 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 16 Jun 2026 23:47:09 +0200
+Subject: [PATCH 17/17] feat(ad_orender): show Atmos profile, bed+objects and
+ DialNorm in track info
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The orender decoder left the codec profile empty, so shift+I showed
+"truehd (orender) [orender]" with no Atmos detail. Compose a profile from
+the engine's presentation info and publish it (double-buffered, rebuilt
+only on change — no per-frame work), e.g.:
+
+  TrueHD [Dolby TrueHD + Dolby Atmos · LFE+11 objects · DialNorm -27 dB] [orender]
+
+Also use official-cased codec names (TrueHD / E-AC-3 / AC-3 / DTS, DTS:X in
+the profile) and drop the redundant "(orender)" from codec_desc — the
+decoder already shows as the trailing [orender] bracket.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 143 ++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 139 insertions(+), 4 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 1bf16c9947..b8158efb65 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -119,6 +119,21 @@ struct priv {
+     int host_decoder_idx;       // HOST_DEC_LAVC (PCM) or HOST_DEC_SPDIF (passthrough)
+     struct mp_decoder *native;  // lazily-created native child decoder for host mode
+     int active_path;            // PATH_* of the last packet, for clean transitions
++    /* Track-info codec profile (shift+I) for the spatial path. Double-buffered so
++     * the property/core thread that reads codec_profile never sees a half-written
++     * or freed string: we write the inactive slot, then atomically publish its
++     * pointer. Rebuilt only when the composed value changes (its inputs are
++     * stable per presentation segment), so the hot path does no work. The cache
++     * (last_*) starts at impossible sentinels so the first frame always
++     * publishes; it is reset on a host->spatial switch because host-mode's child
++     * ad_lavc overwrites codec_profile with its own string. */
++    const char *orender_desc;   // official-cased codec name (codec_desc literal)
++    char profile_buf[2][128];
++    int profile_slot;
++    int last_spatial;
++    int last_objs;
++    int last_dnorm;
++    unsigned last_bed_sig;      // fingerprint of the bed labels (change detection)
+     struct mp_decoder public;
+ };
+ 
+@@ -152,6 +167,104 @@ static int label_to_mp_speaker(uint8_t lbl)
+     }
+ }
+ 
++/* Short display name for a liborender channel label, for the bed composition in
++ * the track-info profile (e.g. "LFE+11 objects"). */
++static const char *label_to_short_name(uint8_t lbl)
++{
++    switch (lbl) {
++    case OR_L:    return "L";
++    case OR_R:    return "R";
++    case OR_C:    return "C";
++    case OR_LFE:  return "LFE";
++    case OR_LS:   return "Ls";
++    case OR_RS:   return "Rs";
++    case OR_TFL:  return "Tfl";
++    case OR_TFR:  return "Tfr";
++    case OR_TSL:  return "Tsl";
++    case OR_TSR:  return "Tsr";
++    case OR_TBL:  return "Tbl";
++    case OR_TBR:  return "Tbr";
++    case OR_LSC:  return "Lsc";
++    case OR_RSC:  return "Rsc";
++    case OR_LB:   return "Lb";
++    case OR_RB:   return "Rb";
++    case OR_CB:   return "Cb";
++    case OR_TC:   return "Tc";
++    case OR_LSD:  return "Lsd";
++    case OR_RSD:  return "Rsd";
++    case OR_LW:   return "Lw";
++    case OR_RW:   return "Rw";
++    case OR_TFC:  return "Tfc";
++    case OR_LFE2: return "LFE2";
++    default:      return "?";
++    }
++}
++
++/* Human profile string for a codec, with/without object (Atmos/DTS:X) content —
++ * mirrors what ffmpeg reports on the native path so shift+I reads the same. */
++static const char *profile_base(const char *codec, bool spatial)
++{
++    if (strcmp(codec, "truehd") == 0)
++        return spatial ? "Dolby TrueHD + Dolby Atmos" : "Dolby TrueHD";
++    if (strcmp(codec, "eac3") == 0)
++        return spatial ? "Dolby Digital Plus + Dolby Atmos" : "Dolby Digital Plus";
++    if (strcmp(codec, "ac3") == 0)
++        return "Dolby Digital";
++    if (strcmp(codec, "dts") == 0)
++        return spatial ? "DTS:X" : "DTS";
++    return codec;
++}
++
++/* Recompose codec_profile from the engine's live presentation info (Atmos flag,
++ * bed composition, object count, DialNorm) and publish it for the track-info
++ * display. Cheap and idempotent: returns immediately unless the value changed. */
++static void refresh_codec_profile(struct priv *p)
++{
++    if (!p->renderer)
++        return;
++
++    int spatial = orender_is_spatial(p->renderer);    // 1 / 0 / <0
++    int objs    = orender_object_count(p->renderer);  // >=0 / -1
++    int dnorm   = orender_dialnorm_db(p->renderer);   // <=0 / INT32_MIN (unknown)
++
++    uint8_t bed[MP_NUM_CHANNELS];
++    uint32_t bedn = orender_bed_layout(p->renderer, bed, MP_NUM_CHANNELS);
++    /* FNV-1a fingerprint of the bed labels, so a bed change (same object count)
++     * still triggers a rebuild. */
++    unsigned bed_sig = 2166136261u;
++    for (uint32_t i = 0; i < bedn; i++)
++        bed_sig = (bed_sig ^ bed[i]) * 16777619u;
++
++    if (spatial == p->last_spatial && objs == p->last_objs &&
++        dnorm == p->last_dnorm && bed_sig == p->last_bed_sig)
++        return;
++
++    int slot = p->profile_slot ^ 1;
++    char *buf = p->profile_buf[slot];
++    size_t cap = sizeof(p->profile_buf[slot]);
++
++    int n = snprintf(buf, cap, "%s", profile_base(p->codec->codec, spatial == 1));
++    /* "· <bed labels>+<N> objects", e.g. "· LFE+11 objects" (no bed → "· N
++     * objects"). Only when there are objects (plain multichannel reports 0). */
++    if (objs > 0 && n > 0 && (size_t)n < cap) {
++        n += snprintf(buf + n, cap - n, " · ");
++        for (uint32_t i = 0; i < bedn && n > 0 && (size_t)n < cap; i++)
++            n += snprintf(buf + n, cap - n, "%s%s",
++                          i ? " " : "", label_to_short_name(bed[i]));
++        if (n > 0 && (size_t)n < cap)
++            n += snprintf(buf + n, cap - n, "%s%d objects", bedn ? "+" : "", objs);
++    }
++    if (dnorm != INT32_MIN && n > 0 && (size_t)n < cap)
++        snprintf(buf + n, cap - n, " · DialNorm %d dB", dnorm);
++
++    p->codec->codec_profile = buf;   // atomic publish of the new slot
++    p->profile_slot = slot;
++    p->last_spatial = spatial;
++    p->last_objs = objs;
++    p->last_dnorm = dnorm;
++    p->last_bed_sig = bed_sig;
++}
++
+ /* Build p->chmap from the renderer's output layout. Returns false if any
+  * speaker had no mpv mapping (caller still proceeds; positions are NA). */
+ static bool build_chmap(struct priv *p)
+@@ -344,6 +457,11 @@ static void process_spatial(struct mp_filter *da, struct priv *p)
+         }
+     }
+ 
++    /* Now that a real frame has decoded, the engine knows the presentation's
++     * Atmos flag, object count and DialNorm — surface them as the track's codec
++     * profile so shift+I matches the native path (and adds objects + DialNorm). */
++    refresh_codec_profile(p);
++
+     out = mp_aframe_create();
+     mp_aframe_set_format(out, AF_FORMAT_FLOAT);   /* interleaved float32 */
+     mp_aframe_set_rate(out, p->sample_rate);
+@@ -412,6 +530,13 @@ static void ad_orender_process(struct mp_filter *da)
+                 orender_reset(p->renderer);
+             p->checked_spatial = false;
+             orender_overlay_set_rendering(1);  // show the spatial overlay again
++            /* A host stint's child ad_lavc overwrote codec_desc/codec_profile
++             * with its own strings; restore our desc and force the next frame to
++             * republish our profile (reset the cache to impossible sentinels). */
++            p->codec->codec_desc = p->orender_desc;
++            p->last_spatial = -1;
++            p->last_objs = -1;
++            p->last_dnorm = 1;
+         } else {
+             if (p->native && p->native->f)
+                 mp_filter_reset(p->native->f);
+@@ -545,14 +670,24 @@ static struct mp_decoder *create(struct mp_filter *parent,
+                       !p->renderer || orender_channel_mode(p->renderer) != 1;
+     orender_overlay_set_rendering(start_host ? 0 : 1);
+ 
++    /* Official-cased codec name. No "(orender)" suffix: the decoder already shows
++     * up as the trailing "[orender]" bracket (codec != decoder). The Atmos /
++     * DTS:X detail lands in the profile bracket built by refresh_codec_profile. */
+     if (strcmp(codec->codec, "eac3") == 0)
+-        codec->codec_desc = "eac3 (orender)";
++        p->orender_desc = "E-AC-3";
+     else if (strcmp(codec->codec, "ac3") == 0)
+-        codec->codec_desc = "ac3 (orender)";
++        p->orender_desc = "AC-3";
+     else if (strcmp(codec->codec, "dts") == 0)
+-        codec->codec_desc = "dts (orender)";
++        p->orender_desc = "DTS";
+     else
+-        codec->codec_desc = "truehd (orender)";
++        p->orender_desc = "TrueHD";
++    codec->codec_desc = p->orender_desc;
++
++    /* Impossible sentinels (real: spatial 0/1, objs >=0, dnorm <=0 or INT32_MIN)
++     * so the first decoded spatial frame always publishes a codec profile. */
++    p->last_spatial = -1;
++    p->last_objs = -1;
++    p->last_dnorm = 1;
+ 
+     return &p->public;
+ }

--- a/src/ad_orender.c
+++ b/src/ad_orender.c
@@ -2,19 +2,26 @@
  * ad_orender.c — mpv audio decoder that renders spatial audio through liborender.
  *
  * Companion to ad_lavc/ad_spdif: when the user opts in with `--ad=orender` on a
- * supported stream, decode + VBAP-render the spatial objects to N-channel
- * float PCM via liborender (orender_*), instead of letting FFmpeg downmix.
+ * supported stream, decode + VBAP-render the spatial objects to N-channel float
+ * PCM via liborender (orender_*), instead of letting FFmpeg downmix.
  *
- * Modeled on ad_spdif.c (a non-lavc mp_filter decoder). liborender does the
- * decode (via a runtime bridge plugin) and the spatial render; this file only
- * shuttles packets in and aframes out through the filter pin protocol.
+ * Unlike the earlier design, ad_orender does NOT hand the track back to the
+ * decoder wrapper in host mode. It stays selected for the whole track and owns
+ * the orender engine the whole time, so the engine's OSC listener — and thus the
+ * Studio connection — stays alive and keeps receiving the live
+ * `channel_render_mode` switch. Each packet is routed on that live mode:
  *
- * Phase 4: opt-in only (so default playback is untouched). The decoder
- * bridge and speaker layout come from the shared omniphony config YAML
- * (render.bridge_path) — the SAME config the orender CLI + studio use
- * (~/.config/omniphony/config.yaml), resolved by liborender when the config
- * path is NULL. The `--ad-orender-*` options, the is_spatial→ad_lavc fallback,
- * and custom chmaps are Phase 5.
+ *   - spatial : decode + VBAP-render through the engine (objects, or the virtual
+ *               bed for plain channel content);
+ *   - host    : delegate to a native child decoder (ad_lavc → PCM, or ad_spdif →
+ *               bitstream passthrough; chosen by --ad-orender-host-decoder) and
+ *               forward its frames untouched.
+ *
+ * Toggling "Spatialize 2D sources" in Studio flips the engine's mode over OSC,
+ * so the switch is applied live, in both directions, with no mpv restart and no
+ * polling — the engine never leaves, never yields the OSC port to the standby
+ * renderer. The bridge and speaker layout come from the shared omniphony config
+ * YAML (render.bridge_path), resolved by liborender when the config path is NULL.
  */
 
 #include <stdbool.h>
@@ -26,6 +33,7 @@
 #include "audio/chmap.h"
 #include "audio/format.h"
 #include "common/codecs.h"
+#include "common/common.h"
 #include "common/msg.h"
 #include "demux/packet.h"
 #include "demux/stheader.h"
@@ -49,6 +57,8 @@ struct ad_orender_params {
     int osc_rx_port;            // incoming control port  (0 = config/default 9000)
     char *osc_bind;             // listener bind address (else config/default)
     char *osc_monitor_target;   // monitoring host (else config/default)
+    int channel_mode_idx;       // initial render override: 0=auto 1=host 2=spatial
+    int host_decoder_idx;       // host-mode native decoder: 0=lavc 1=spdif
 };
 
 const struct m_sub_options ad_orender_conf = {
@@ -60,6 +70,17 @@ const struct m_sub_options ad_orender_conf = {
         {"osc-rx-port", OPT_INT(osc_rx_port), M_RANGE(0, 65535)},
         {"osc-bind", OPT_STRING(osc_bind)},
         {"osc-monitor-target", OPT_STRING(osc_monitor_target)},
+        /* Initial render mode for channel-based (non-object) content. "auto" =
+         * follow the shared config's render.channel_render_mode. "host" decodes
+         * natively (see host-decoder); "spatial" renders through orender's
+         * virtual bed. "direct"/"virtual" are legacy aliases of "spatial". The
+         * live mode is then driven by Studio over OSC. */
+        {"channel-mode", OPT_CHOICE(channel_mode_idx,
+            {"auto", 0}, {"host", 1}, {"spatial", 2}, {"direct", 2}, {"virtual", 2})},
+        /* Which native decoder to use in host mode: "lavc" decodes to PCM (mpv's
+         * audio chain applies — the default), "spdif" passes the compressed
+         * bitstream through to an AV receiver. */
+        {"host-decoder", OPT_CHOICE(host_decoder_idx, {"lavc", 0}, {"spdif", 1})},
         {0}
     },
     .size = sizeof(struct ad_orender_params),
@@ -72,6 +93,9 @@ const struct m_sub_options ad_orender_conf = {
 
 /* An empty option string means "unset" → pass NULL to the FFI. */
 static const char *nz(const char *s) { return (s && s[0]) ? s : NULL; }
+
+enum { HOST_DEC_LAVC = 0, HOST_DEC_SPDIF = 1 };
+enum { PATH_NONE = -1, PATH_HOST = 0, PATH_SPATIAL = 1 };
 
 /* liborender channel labels — mirror bridge_api::RChannelLabel. cbindgen runs
  * with parse_deps=false, so orender.h does not emit this enum; keep in sync. */
@@ -90,7 +114,26 @@ struct priv {
     int sample_rate;
     int channels;
     struct mp_chmap chmap;
-    bool checked_spatial;
+    bool checked_spatial;       // built the output chmap for the spatial path
+    bool force_host;            // engine unusable (no layout / create failed): always native
+    int host_decoder_idx;       // HOST_DEC_LAVC (PCM) or HOST_DEC_SPDIF (passthrough)
+    struct mp_decoder *native;  // lazily-created native child decoder for host mode
+    int active_path;            // PATH_* of the last packet, for clean transitions
+    /* Track-info codec profile (shift+I) for the spatial path. Double-buffered so
+     * the property/core thread that reads codec_profile never sees a half-written
+     * or freed string: we write the inactive slot, then atomically publish its
+     * pointer. Rebuilt only when the composed value changes (its inputs are
+     * stable per presentation segment), so the hot path does no work. The cache
+     * (last_*) starts at impossible sentinels so the first frame always
+     * publishes; it is reset on a host->spatial switch because host-mode's child
+     * ad_lavc overwrites codec_profile with its own string. */
+    const char *orender_desc;   // official-cased codec name (codec_desc literal)
+    char profile_buf[2][128];
+    int profile_slot;
+    int last_spatial;
+    int last_objs;
+    int last_dnorm;
+    unsigned last_bed_sig;      // fingerprint of the bed labels (change detection)
     struct mp_decoder public;
 };
 
@@ -124,6 +167,104 @@ static int label_to_mp_speaker(uint8_t lbl)
     }
 }
 
+/* Short display name for a liborender channel label, for the bed composition in
+ * the track-info profile (e.g. "LFE+11 objects"). */
+static const char *label_to_short_name(uint8_t lbl)
+{
+    switch (lbl) {
+    case OR_L:    return "L";
+    case OR_R:    return "R";
+    case OR_C:    return "C";
+    case OR_LFE:  return "LFE";
+    case OR_LS:   return "Ls";
+    case OR_RS:   return "Rs";
+    case OR_TFL:  return "Tfl";
+    case OR_TFR:  return "Tfr";
+    case OR_TSL:  return "Tsl";
+    case OR_TSR:  return "Tsr";
+    case OR_TBL:  return "Tbl";
+    case OR_TBR:  return "Tbr";
+    case OR_LSC:  return "Lsc";
+    case OR_RSC:  return "Rsc";
+    case OR_LB:   return "Lb";
+    case OR_RB:   return "Rb";
+    case OR_CB:   return "Cb";
+    case OR_TC:   return "Tc";
+    case OR_LSD:  return "Lsd";
+    case OR_RSD:  return "Rsd";
+    case OR_LW:   return "Lw";
+    case OR_RW:   return "Rw";
+    case OR_TFC:  return "Tfc";
+    case OR_LFE2: return "LFE2";
+    default:      return "?";
+    }
+}
+
+/* Human profile string for a codec, with/without object (Atmos/DTS:X) content —
+ * mirrors what ffmpeg reports on the native path so shift+I reads the same. */
+static const char *profile_base(const char *codec, bool spatial)
+{
+    if (strcmp(codec, "truehd") == 0)
+        return spatial ? "Dolby TrueHD + Dolby Atmos" : "Dolby TrueHD";
+    if (strcmp(codec, "eac3") == 0)
+        return spatial ? "Dolby Digital Plus + Dolby Atmos" : "Dolby Digital Plus";
+    if (strcmp(codec, "ac3") == 0)
+        return "Dolby Digital";
+    if (strcmp(codec, "dts") == 0)
+        return spatial ? "DTS:X" : "DTS";
+    return codec;
+}
+
+/* Recompose codec_profile from the engine's live presentation info (Atmos flag,
+ * bed composition, object count, DialNorm) and publish it for the track-info
+ * display. Cheap and idempotent: returns immediately unless the value changed. */
+static void refresh_codec_profile(struct priv *p)
+{
+    if (!p->renderer)
+        return;
+
+    int spatial = orender_is_spatial(p->renderer);    // 1 / 0 / <0
+    int objs    = orender_object_count(p->renderer);  // >=0 / -1
+    int dnorm   = orender_dialnorm_db(p->renderer);   // <=0 / INT32_MIN (unknown)
+
+    uint8_t bed[MP_NUM_CHANNELS];
+    uint32_t bedn = orender_bed_layout(p->renderer, bed, MP_NUM_CHANNELS);
+    /* FNV-1a fingerprint of the bed labels, so a bed change (same object count)
+     * still triggers a rebuild. */
+    unsigned bed_sig = 2166136261u;
+    for (uint32_t i = 0; i < bedn; i++)
+        bed_sig = (bed_sig ^ bed[i]) * 16777619u;
+
+    if (spatial == p->last_spatial && objs == p->last_objs &&
+        dnorm == p->last_dnorm && bed_sig == p->last_bed_sig)
+        return;
+
+    int slot = p->profile_slot ^ 1;
+    char *buf = p->profile_buf[slot];
+    size_t cap = sizeof(p->profile_buf[slot]);
+
+    int n = snprintf(buf, cap, "%s", profile_base(p->codec->codec, spatial == 1));
+    /* "· <bed labels>+<N> objects", e.g. "· LFE+11 objects" (no bed → "· N
+     * objects"). Only when there are objects (plain multichannel reports 0). */
+    if (objs > 0 && n > 0 && (size_t)n < cap) {
+        n += snprintf(buf + n, cap - n, " · ");
+        for (uint32_t i = 0; i < bedn && n > 0 && (size_t)n < cap; i++)
+            n += snprintf(buf + n, cap - n, "%s%s",
+                          i ? " " : "", label_to_short_name(bed[i]));
+        if (n > 0 && (size_t)n < cap)
+            n += snprintf(buf + n, cap - n, "%s%d objects", bedn ? "+" : "", objs);
+    }
+    if (dnorm != INT32_MIN && n > 0 && (size_t)n < cap)
+        snprintf(buf + n, cap - n, " · DialNorm %d dB", dnorm);
+
+    p->codec->codec_profile = buf;   // atomic publish of the new slot
+    p->profile_slot = slot;
+    p->last_spatial = spatial;
+    p->last_objs = objs;
+    p->last_dnorm = dnorm;
+    p->last_bed_sig = bed_sig;
+}
+
 /* Build p->chmap from the renderer's output layout. Returns false if any
  * speaker had no mpv mapping (caller still proceeds; positions are NA). */
 static bool build_chmap(struct priv *p)
@@ -146,27 +287,84 @@ static bool build_chmap(struct priv *p)
     return ok;
 }
 
-static void ad_orender_destroy(struct mp_filter *da)
+/* Try each entry in `sel` with `fns->create`, stopping at the first success. */
+static bool try_create_child(struct mp_filter *da, struct priv *p,
+                             const struct mp_decoder_fns *fns,
+                             struct mp_decoder_list *sel)
 {
-    struct priv *p = da->priv;
-    if (p->renderer) {
-        orender_destroy(p->renderer);
-        p->renderer = NULL;
+    for (int i = 0; i < sel->num_entries; i++) {
+        p->native = fns->create(da, p->codec, sel->entries[i].decoder);
+        if (p->native) {
+            MP_VERBOSE(da, "host-mode native decoder: %s\n", sel->entries[i].decoder);
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Lazily create the native child decoder for host mode, picking the right driver
+ * + decoder for the codec via mpv's normal selection (so e.g. dts → "dca"). With
+ * host-decoder=spdif, request bitstream passthrough for this codec; if that is
+ * not available, fall back to lavc rather than leaving the track undecodable. */
+static bool ensure_native_child(struct mp_filter *da, struct priv *p)
+{
+    if (p->native)
+        return true;
+
+    if (p->host_decoder_idx == HOST_DEC_SPDIF) {
+        /* select_spdif_codec only enables passthrough for codecs listed in its
+         * `pref`; pass this codec so the explicit choice takes effect. */
+        struct mp_decoder_list *sel = select_spdif_codec(p->codec->codec, p->codec->codec);
+        bool ok = try_create_child(da, p, &ad_spdif, sel);
+        talloc_free(sel);
+        if (!ok)
+            MP_WARN(da, "spdif passthrough unavailable for %s; using lavc\n",
+                    p->codec->codec);
+    }
+
+    if (!p->native) {
+        struct mp_decoder_list *all = talloc_zero(NULL, struct mp_decoder_list);
+        ad_lavc.add_decoders(all);
+        struct mp_decoder_list *sel = mp_select_decoders(p->log, all, p->codec->codec, NULL);
+        talloc_free(all);
+        try_create_child(da, p, &ad_lavc, sel);
+        talloc_free(sel);
+    }
+
+    if (!p->native) {
+        MP_ERR(da, "could not create a host-mode native decoder for %s\n",
+               p->codec->codec);
+        return false;
+    }
+    return true;
+}
+
+/* Host mode: pump the native child — forward packets in, decoded frames out. */
+static void process_host(struct mp_filter *da, struct priv *p)
+{
+    if (!ensure_native_child(da, p)) {
+        mp_filter_internal_mark_failed(da);
+        return;
+    }
+
+    struct mp_pin *child_in = p->native->f->pins[0];
+    struct mp_pin *child_out = p->native->f->pins[1];
+
+    // Drain decoded frames to our output (and forward EOF transparently).
+    if (mp_pin_can_transfer_data(da->ppins[1], child_out)) {
+        struct mp_frame frame = mp_pin_out_read(child_out);
+        mp_pin_in_write(da->ppins[1], frame);
+    }
+    // Feed input packets to the child.
+    if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
+        struct mp_frame frame = mp_pin_out_read(da->ppins[0]);
+        mp_pin_in_write(child_in, frame);
     }
 }
 
-static void ad_orender_reset(struct mp_filter *da)
+/* Spatial mode: decode + VBAP-render through the engine. */
+static void process_spatial(struct mp_filter *da, struct priv *p)
 {
-    struct priv *p = da->priv;
-    if (p->renderer)
-        orender_reset(p->renderer);
-    p->checked_spatial = false;
-}
-
-static void ad_orender_process(struct mp_filter *da)
-{
-    struct priv *p = da->priv;
-
     if (!mp_pin_can_transfer_data(da->ppins[1], da->ppins[0]))
         return;
 
@@ -215,20 +413,29 @@ static void ad_orender_process(struct mp_filter *da)
         goto done;
     }
 
-    /* Resolve spatial-vs-plain + the output chmap on the first decoded packet. */
-    if (!p->checked_spatial) {
-        p->checked_spatial = true;
-        if (orender_is_spatial(p->renderer) != 1) {
-            MP_WARN(da, "no spatial objects detected; rendering the bed only "
-                        "(decode this track without --ad=orender for the "
-                        "standard downmix)\n");
-        }
-        if (!build_chmap(p))
-            MP_WARN(da, "output layout has speakers with no mpv mapping\n");
-    }
-
     if (n_frames == 0)
         goto done;   /* packet consumed; no output yet (need more data) */
+
+    /* Resolve the output chmap on the first *decoded* frame. Deferred until
+     * n_frames > 0: the layout is only meaningful once the bridge has decoded a
+     * frame (AC-3/DTS need several packets to acquire sync). */
+    if (!p->checked_spatial) {
+        p->checked_spatial = true;
+        if (!build_chmap(p)) {
+            if (p->chmap.num == 0) {
+                /* The renderer reported no output channels (e.g. the speaker
+                 * layout could not be resolved). Spatial rendering is impossible,
+                 * so route to the native host decoder for the rest of the track
+                 * rather than dropping every frame (which would freeze audio). */
+                MP_WARN(da, "renderer reported no output layout; decoding "
+                            "natively instead (check the speaker layout in your "
+                            "omniphony config)\n");
+                p->force_host = true;
+                goto done;
+            }
+            MP_WARN(da, "output layout has speakers with no mpv mapping\n");
+        }
+    }
 
     /* Live output-mode switches change the channel count mid-stream: rebuild
      * the chmap so the frame below is allocated for what we actually copy —
@@ -249,6 +456,11 @@ static void ad_orender_process(struct mp_filter *da)
             goto done;
         }
     }
+
+    /* Now that a real frame has decoded, the engine knows the presentation's
+     * Atmos flag, object count and DialNorm — surface them as the track's codec
+     * profile so shift+I matches the native path (and adds objects + DialNorm). */
+    refresh_codec_profile(p);
 
     out = mp_aframe_create();
     mp_aframe_set_format(out, AF_FORMAT_FLOAT);   /* interleaved float32 */
@@ -286,6 +498,83 @@ done:
         mp_pin_in_write(da->ppins[1], MAKE_FRAME(MP_FRAME_AUDIO, out));
     } else if (failed) {
         mp_filter_internal_mark_failed(da);
+    } else {
+        // No output frame this pass: re-run so the graph stays active. The bridge
+        // needs several packets to acquire sync for some codecs (AC-3/DTS) before
+        // the first decoded frame, so early packets legitimately yield zero
+        // frames; re-running requests the next packet. Without this mpv never
+        // gets a first frame, the audio output is never created, and playback
+        // freezes on the first video frame with no sound. (Also covers the
+        // re-sync after a host→spatial switch, where the bridge was just reset.)
+        mp_filter_internal_mark_progress(da);
+    }
+}
+
+static void ad_orender_process(struct mp_filter *da)
+{
+    struct priv *p = da->priv;
+
+    /* Route on the engine's live channel_render_mode (0 host, 1 spatial), which
+     * Studio flips over OSC. Reading it per packet is a cheap in-memory call, not
+     * a poll. `force_host` (engine unusable) pins host. */
+    int mode = p->renderer ? orender_channel_mode(p->renderer) : 0;
+    bool host = p->force_host || mode != 1;
+    int path = host ? PATH_HOST : PATH_SPATIAL;
+
+    /* On a mode flip, flush stale state on the side we switch *to* so it starts
+     * clean: the engine's bridge re-acquires sync (it wasn't fed during host),
+     * and the native child drops any partial state from a previous host stint. */
+    if (path != p->active_path) {
+        if (path == PATH_SPATIAL) {
+            if (p->renderer)
+                orender_reset(p->renderer);
+            p->checked_spatial = false;
+            orender_overlay_set_rendering(1);  // show the spatial overlay again
+            /* A host stint's child ad_lavc overwrote codec_desc/codec_profile
+             * with its own strings; restore our desc and force the next frame to
+             * republish our profile (reset the cache to impossible sentinels). */
+            p->codec->codec_desc = p->orender_desc;
+            p->last_spatial = -1;
+            p->last_objs = -1;
+            p->last_dnorm = 1;
+        } else {
+            if (p->native && p->native->f)
+                mp_filter_reset(p->native->f);
+            /* Hide the whole spatial overlay (wireframe cube included) while we
+             * decode natively — nothing is being spatialized — and drop the stale
+             * scene so it does not linger. The user's overlay on/off preference is
+             * preserved; spatial mode repopulates it. */
+            orender_overlay_set_rendering(0);
+            orender_overlay_clear();
+        }
+        p->active_path = path;
+    }
+
+    if (host)
+        process_host(da, p);
+    else
+        process_spatial(da, p);
+}
+
+static void ad_orender_reset(struct mp_filter *da)
+{
+    struct priv *p = da->priv;
+    if (p->renderer)
+        orender_reset(p->renderer);
+    if (p->native && p->native->f)
+        mp_filter_reset(p->native->f);
+    p->checked_spatial = false;
+    p->active_path = PATH_NONE;
+}
+
+static void ad_orender_destroy(struct mp_filter *da)
+{
+    struct priv *p = da->priv;
+    /* The native child is a talloc child of `da` and is freed with it; the
+     * engine is an FFI handle we must release explicitly. */
+    if (p->renderer) {
+        orender_destroy(p->renderer);
+        p->renderer = NULL;
     }
 }
 
@@ -302,9 +591,9 @@ static struct mp_decoder *create(struct mp_filter *parent,
                                  const char *decoder)
 {
     if (!codec->codec ||
-        (strcmp(codec->codec, "truehd") != 0 && strcmp(codec->codec, "eac3") != 0))
+        (strcmp(codec->codec, "truehd") != 0 && strcmp(codec->codec, "eac3") != 0 &&
+         strcmp(codec->codec, "ac3") != 0 && strcmp(codec->codec, "dts") != 0))
         return NULL;
-    bool is_eac3 = strcmp(codec->codec, "eac3") == 0;
 
     struct mp_filter *da = mp_filter_create(parent, &ad_orender_filter);
     if (!da)
@@ -319,10 +608,12 @@ static struct mp_decoder *create(struct mp_filter *parent,
     p->log = da->log;
     p->codec = codec;
     p->sample_rate = codec->samplerate;
+    p->active_path = PATH_NONE;
     p->public.f = da;
 
     struct ad_orender_params *opts =
         mp_get_config_group(da, da->global, &ad_orender_conf);
+    p->host_decoder_idx = opts->host_decoder_idx;
 
     OrenderConfig cfg = {
         .sample_rate         = p->sample_rate,
@@ -346,26 +637,57 @@ static struct mp_decoder *create(struct mp_filter *parent,
 
     p->renderer = orender_create(&cfg);
     if (!p->renderer) {
-        /* liborender resolves the config per-OS (see
-         * renderer/src/config.rs::default_config_path): %ProgramData% on
-         * Windows (machine-wide, shared with the service), $XDG_CONFIG_HOME
-         * (or ~/.config) elsewhere. Match its convention in the hint. */
+        /* The engine could not start (e.g. a bad render.bridge_path). Rather than
+         * leave the track with no decoder at all, stay selected and decode
+         * natively for the whole session (host). Spatial is impossible until the
+         * config is fixed and mpv restarted, but audio still plays. */
 #ifdef _WIN32
-        MP_ERR(da, "orender_create failed — set render.bridge_path in your "
-                   "omniphony config (%%ProgramData%%\\omniphony\\config.yaml); "
-                   "see stderr for the liborender error\n");
+        MP_ERR(da, "orender_create failed — decoding natively. Set "
+                   "render.bridge_path in your omniphony config "
+                   "(%%ProgramData%%\\omniphony\\config.yaml); see stderr.\n");
 #else
-        MP_ERR(da, "orender_create failed — set render.bridge_path in your "
-                   "omniphony config (~/.config/omniphony/config.yaml); see "
-                   "stderr for the liborender error\n");
+        MP_ERR(da, "orender_create failed — decoding natively. Set "
+                   "render.bridge_path in your omniphony config "
+                   "(~/.config/omniphony/config.yaml); see stderr.\n");
 #endif
-        talloc_free(da);
-        return NULL;
+        p->force_host = true;
     }
 
-    p->channels = orender_channel_count(p->renderer);
-    codec->codec_desc = is_eac3 ? "eac3 (orender, spatial)"
-                                : "truehd (orender, spatial)";
+    /* Per-invocation override of the shared config's initial channel render mode.
+     * Option values: 0=auto (follow config), 1=host, 2=spatial (direct/virtual
+     * are legacy aliases of spatial). FFI mode codes: 0=host, 1=spatial — so
+     * `value - 1` maps host(1)→0 and spatial(2)→1. The live mode is then driven
+     * by Studio over OSC. */
+    if (p->renderer && opts->channel_mode_idx > 0)
+        orender_set_channel_mode(p->renderer, opts->channel_mode_idx - 1);
+
+    if (p->renderer)
+        p->channels = orender_channel_count(p->renderer);
+
+    /* Match the overlay's initial visibility to the starting mode, so it does not
+     * flash the wireframe cube before the first packet picks the path. */
+    bool start_host = p->force_host ||
+                      !p->renderer || orender_channel_mode(p->renderer) != 1;
+    orender_overlay_set_rendering(start_host ? 0 : 1);
+
+    /* Official-cased codec name. No "(orender)" suffix: the decoder already shows
+     * up as the trailing "[orender]" bracket (codec != decoder). The Atmos /
+     * DTS:X detail lands in the profile bracket built by refresh_codec_profile. */
+    if (strcmp(codec->codec, "eac3") == 0)
+        p->orender_desc = "E-AC-3";
+    else if (strcmp(codec->codec, "ac3") == 0)
+        p->orender_desc = "AC-3";
+    else if (strcmp(codec->codec, "dts") == 0)
+        p->orender_desc = "DTS";
+    else
+        p->orender_desc = "TrueHD";
+    codec->codec_desc = p->orender_desc;
+
+    /* Impossible sentinels (real: spatial 0/1, objs >=0, dnorm <=0 or INT32_MIN)
+     * so the first decoded spatial frame always publishes a codec profile. */
+    p->last_spatial = -1;
+    p->last_objs = -1;
+    p->last_dnorm = 1;
 
     return &p->public;
 }
@@ -375,6 +697,10 @@ static void add_decoders(struct mp_decoder_list *list)
     mp_add_decoder(list, "truehd", "orender",
                    "Spatial audio via liborender (VBAP object rendering)");
     mp_add_decoder(list, "eac3", "orender",
+                   "Spatial audio via liborender (VBAP object rendering)");
+    mp_add_decoder(list, "ac3", "orender",
+                   "Spatial audio via liborender (VBAP object rendering)");
+    mp_add_decoder(list, "dts", "orender",
                    "Spatial audio via liborender (VBAP object rendering)");
 }
 


### PR DESCRIPTION
Cuts the **0.4.0** lockstep release (matches Omniphony v0.4.0 / harletty v0.7.0).

- Regenerate `patches/` from the fork's `orender` branch — now 17 patches, adding the channel-mode host/spatial routing (0012–0016) and the ad_orender **track-info profile** (0017: Atmos, bed/objects, DialNorm).
- Sync `src/ad_orender.c`.
- Bump `OMNIPHONY_REF` `v0.3.3 → v0.4.0` so the bundle's liborender is built from Omniphony v0.4.0.

Validated: re-curated `orender` `ad_orender.c` is byte-identical to the tested `orender-release`, `f_decoder_wrapper.h` matches `orender-master`, and both compile against mpv v0.41.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)