### PR TITLE
fix(release): don't trigger stable release on FEL beta tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
   push:
     tags:
       - 'v*'
+      # FEL beta tags (e.g. v0.4.0-fel-beta.1) are built + published by
+      # build-fel.yml on the master track; keep them off the stable release.
+      - '!*-fel*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
`release.yml` has no branch guard, so the `v0.4.0-fel-beta.1` tag (matching `v*`) wrongly started a stable-track build alongside the intended `build-fel.yml` run. Exclude `*-fel*` tags from `release.yml` — FEL betas are built + published by `build-fel.yml` on the master track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)