### PR TITLE
ci(macos): build mpv + liborender for macOS arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 # Triggered by a v* tag.
-# Cross-compiles mpv (with our ad_orender patches) for Linux and Windows,
-# bundles each with the matching liborender release artifacts, and creates a
-# draft GitHub release.
+# Builds mpv (with our ad_orender patches) for Linux, Windows (MinGW cross) and
+# macOS arm64 (native), bundles each with the matching liborender artifacts, and
+# creates a draft GitHub release.
 #
 # The decoder bridge is NOT bundled — it carries licensing constraints that
 # require the user to download it separately (see README).
@@ -391,8 +391,98 @@ jobs:
           name: mpv-omniphony-windows-x86_64
           path: mpv-omniphony-*-windows-x86_64.zip
 
+  # macOS (Apple Silicon): mpv builds natively, so liborender is built in the
+  # same job (like the Linux job, unlike the Windows cross-compile split).
+  build-macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mpv build deps (Homebrew)
+        run: |
+          brew update
+          brew install meson ninja pkg-config ffmpeg libass libplacebo luajit
+
+      - name: Checkout Omniphony (renderer source)
+        uses: actions/checkout@v4
+        with:
+          repository: mgth/Omniphony
+          ref: ${{ env.OMNIPHONY_REF }}
+          path: omniphony
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build liborender from source
+        # orender_ffi only pulls orender_engine (audio-free) — same minimal
+        # build as the Linux/Windows liborender jobs.
+        run: cargo build --release -p orender_ffi
+        working-directory: omniphony/omniphony-renderer
+        env:
+          RUSTFLAGS: -D warnings
+
+      - name: Install liborender into sysroot
+        run: |
+          mkdir -p sysroot/usr/lib sysroot/usr/include sysroot/usr/lib/pkgconfig
+          rel=omniphony/omniphony-renderer/target/release
+          # No soname symlink needed on macOS; the release dylib already carries
+          # an `@rpath/liborender.dylib` install name (orender_ffi/build.rs).
+          cp "$rel/liborender.dylib" sysroot/usr/lib/liborender.dylib
+          cp omniphony/omniphony-renderer/orender_ffi/include/orender.h sysroot/usr/include/orender.h
+          # Hand-write a minimal pkg-config so mpv's meson finds liborender.
+          ver="${OMNIPHONY_REF#v}"
+          cat > sysroot/usr/lib/pkgconfig/orender.pc <<EOF
+          prefix=${{ github.workspace }}/sysroot/usr
+          libdir=\${prefix}/lib
+          includedir=\${prefix}/include
+
+          Name: orender
+          Description: Omniphony renderer C library
+          Version: ${ver}
+          Libs: -L\${libdir} -lorender
+          Cflags: -I\${includedir}
+          EOF
+
+      - name: Apply patches onto mpv
+        run: bash scripts/apply-patches.sh "$MPV_TAG"
+
+      - name: Build mpv with ad_orender
+        run: |
+          # Prepend our sysroot, then Homebrew's pkgconfig so meson finds both
+          # liborender and the brew-installed ffmpeg/libass/libplacebo/luajit.
+          export PKG_CONFIG_PATH="${{ github.workspace }}/sysroot/usr/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          cd "build/mpv-${MPV_TAG}"
+          meson setup _b -Dorender=enabled
+          meson compile -C _b
+
+      - name: Package (zip)
+        run: |
+          mkdir -p staging
+          cp "build/mpv-${MPV_TAG}/_b/mpv" staging/
+          cp sysroot/usr/lib/liborender.dylib staging/
+          cp sysroot/usr/include/orender.h staging/
+          cp README.md staging/
+          # Make the bundle relocatable regardless of the install name liborender
+          # was built with (older OMNIPHONY_REFs lack the @rpath id): normalise the
+          # dylib id, repoint mpv's reference to it, and add an @loader_path rpath
+          # so mpv loads the copy bundled beside it.
+          install_name_tool -id @rpath/liborender.dylib staging/liborender.dylib
+          old_ref=$(otool -L staging/mpv | awk '/liborender\.dylib/ {print $1; exit}')
+          if [ -n "$old_ref" ] && [ "$old_ref" != "@rpath/liborender.dylib" ]; then
+            install_name_tool -change "$old_ref" @rpath/liborender.dylib staging/mpv
+          fi
+          install_name_tool -add_rpath @loader_path staging/mpv 2>/dev/null || true
+          cd staging
+          zip -r "../mpv-omniphony-${GITHUB_REF_NAME}-macos-arm64.zip" \
+            mpv liborender.dylib orender.h README.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mpv-omniphony-macos-arm64
+          path: mpv-omniphony-*-macos-arm64.zip
+
   release:
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -404,6 +494,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: mpv-omniphony-windows-x86_64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mpv-omniphony-macos-arm64
 
       - name: Create draft release
         uses: softprops/action-gh-release@v2
@@ -429,9 +523,10 @@ jobs:
             underlying codec mean users must obtain it themselves from
             [harletty-bridge](https://github.com/harletty/harletty-bridge/releases),
             and point mpv at it with
-            `--ad-orender-bridge-path=/path/to/bridge.{so,dll}`.
+            `--ad-orender-bridge-path=/path/to/bridge.{so,dll,dylib}`.
 
             liborender built from source at Omniphony ${{ env.OMNIPHONY_REF }}.
           files: |
             mpv-omniphony-*-linux-x86_64.zip
             mpv-omniphony-*-windows-x86_64.zip
+            mpv-omniphony-*-macos-arm64.zip


### PR DESCRIPTION
## Summary
Add a native `macos-14` job that builds liborender from `OMNIPHONY_REF`, hand-writes `orender.pc`, and compiles mpv (`meson -Dorender=enabled`) against Homebrew deps. mpv outputs through its own CoreAudio backend.

The bundle is made relocatable independently of liborender's install name (normalise the dylib id to `@rpath`, repoint mpv's reference, add an `@loader_path` rpath), so it works even against an `OMNIPHONY_REF` that predates the renderer's `@rpath` change.

Reminder: the decoder bridge is still user-supplied — `--ad-orender-bridge-path=…/libharletty_bridge.dylib`.

## Testing
Builds run on `v*` tags; exercised by the first beta tag. For a fully working bundle, bump `OMNIPHONY_REF` to a renderer ref containing the macOS work once it lands on a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
