### PR TITLE
release: bump OMNIPHONY_REF to v0.4.1-beta.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
   # construction, and removes the stale-prebuilt skew that made mpv silently
   # ship an old liborender (config parsed differently → default room). Bump
   # this one line on each release.
-  OMNIPHONY_REF: v0.4.1-beta.1
+  OMNIPHONY_REF: v0.4.1-beta.2
 
 jobs:
   build-linux:


### PR DESCRIPTION
Pick up the macOS sys portability fix so the macOS liborender build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)