### PR TITLE
fix(release): build Direct3D 11 support into the Windows mpv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,8 @@ jobs:
             mingw-w64-meson \
             mingw-w64-ffmpeg \
             mingw-w64-libplacebo \
-            mingw-w64-libass
+            mingw-w64-libass \
+            mingw-w64-spirv-cross
 
       - name: Build & install libsrt from source (ABI-matched to our libstdc++)
         run: |
@@ -321,7 +322,8 @@ jobs:
             --cross-file="$GITHUB_WORKSPACE/sysroot/mingw-cross.ini" \
             -Dorender=enabled \
             -Dlua=lua52 \
-            -Dasio=enabled
+            -Dasio=enabled \
+            -Dd3d11=enabled
           meson compile -C _b
 
       - name: Package (zip)


### PR DESCRIPTION
The Windows bundle shipped without the Direct3D 11 GPU backend: `spirv-cross-c-shared` wasn't installed, so mpv's `d3d11` feature auto-disabled. Users with `gpu-api=d3d11` / `gpu-context=d3d11` in mpv.conf got "option not found" and a frozen video output.

Install `mingw-w64-spirv-cross` and pin `-Dd3d11=enabled` (fail-loud). Mirrors the same fix in `build-fel.yml` (+ `-Dd3d11=enabled` in the custom libplacebo via `build-fel-deps.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)