### PR TITLE
fix(release): propagate ad_orender object-label fix + enable CUDA hwaccel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,16 @@ jobs:
           Cflags: -I\${includedir}
           EOF
 
+      - name: Install nv-codec-headers (CUDA hwaccel)
+        run: |
+          # mpv's cuda-hwaccel/cuda-interop only need the ffnvcodec headers at
+          # build time; libcuda/libnvcuvid are dlopen'd at runtime on the user's
+          # machine, so no CUDA SDK is required here. Install into the same
+          # sysroot that is already on PKG_CONFIG_PATH for the mpv build below.
+          git clone --depth 1 --branch n13.0.19.0 \
+            https://github.com/FFmpeg/nv-codec-headers nv-codec-headers
+          make -C nv-codec-headers install PREFIX="${{ github.workspace }}/sysroot/usr"
+
       - name: Apply patches onto mpv
         run: bash scripts/apply-patches.sh "$MPV_TAG"
 
@@ -88,7 +98,9 @@ jobs:
           export PKG_CONFIG_PATH="${{ github.workspace }}/sysroot/usr/lib/pkgconfig"
           export LD_LIBRARY_PATH="${{ github.workspace }}/sysroot/usr/lib"
           cd "build/mpv-${MPV_TAG}"
-          meson setup _b -Dorender=enabled
+          # cuda-hwaccel/-interop forced on so the released binary always carries
+          # NVIDIA hardware decoding (ffnvcodec provided by the step above).
+          meson setup _b -Dorender=enabled -Dcuda-hwaccel=enabled -Dcuda-interop=enabled
           meson compile -C _b
 
       - name: Package (zip)
@@ -254,6 +266,19 @@ jobs:
           EOF
           x86_64-w64-mingw32-pkg-config --modversion lua52
 
+      - name: Build & install nv-codec-headers (CUDA hwaccel, MinGW)
+        run: |
+          # Header-only ffnvcodec install so mpv's cuda-hwaccel can configure for
+          # the MinGW target; nvcuda/nvcuvid are loaded at runtime on the user's
+          # NVIDIA machine, so nothing else is needed at cross-compile time.
+          # Installs ffnvcodec.pc into $SYS/lib/pkgconfig, where the MinGW
+          # pkg-config wrapper looks (same place lua52.pc / orender.pc land).
+          SYS=/usr/x86_64-w64-mingw32
+          git clone --depth 1 --branch n13.0.19.0 \
+            https://github.com/FFmpeg/nv-codec-headers nv-codec-headers
+          make -C nv-codec-headers install PREFIX="$SYS"
+          x86_64-w64-mingw32-pkg-config --modversion ffnvcodec
+
       - name: Download liborender (built from source)
         uses: actions/download-artifact@v4
         with:
@@ -318,12 +343,18 @@ jobs:
           cd "build/mpv-${MPV_TAG}"
           # Lua 5.2 is built from source in a previous step and installed into
           # $SYS — mpv's `dependency('lua52')` finds it via pkg-config.
+          # cuda-hwaccel forced on (ffnvcodec installed above) so the Windows
+          # binary carries NVIDIA hardware decoding. cuda-interop is left at auto:
+          # the MinGW GL/D3D interop path is less certain to configure here, and
+          # decode (hwaccel) is what "CUDA support" requires — interop is only a
+          # zero-copy display optimisation on top.
           meson setup _b \
             --cross-file="$GITHUB_WORKSPACE/sysroot/mingw-cross.ini" \
             -Dorender=enabled \
             -Dlua=lua52 \
             -Dasio=enabled \
-            -Dd3d11=enabled
+            -Dd3d11=enabled \
+            -Dcuda-hwaccel=enabled
           meson compile -C _b
 
       - name: Package (zip)

--- a/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/17] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/18] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/17] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/18] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/17] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/18] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/17] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/18] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/17] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/18] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/17] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/18] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/17] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/18] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/17] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/18] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/17] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/18] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/17] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/18] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 13 Jun 2026 11:10:05 +0200
-Subject: [PATCH 11/17] ad_orender: ProgramData config path in the Windows
+Subject: [PATCH 11/18] ad_orender: ProgramData config path in the Windows
  bridge_path hint
 
 The renderer's Windows default config moved to %ProgramData%\omniphony\

--- a/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
+++ b/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 14:28:27 +0200
-Subject: [PATCH 12/17] ad_orender: host channel-mode fallback to the native
+Subject: [PATCH 12/18] ad_orender: host channel-mode fallback to the native
  decoder
 
 Add --ad-orender-channel-mode (auto/host/direct/virtual) and, in host mode on a

--- a/patches/0013-ad_orender-route-DTS-to-orender-too.patch
+++ b/patches/0013-ad_orender-route-DTS-to-orender-too.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 16:37:06 +0200
-Subject: [PATCH 13/17] ad_orender: route DTS to orender too
+Subject: [PATCH 13/18] ad_orender: route DTS to orender too
 
 Add "dts" to the codec gate in f_decoder_wrapper (decoder selection) and
 ad_orender (create + add_decoders + codec_desc), so DTS tracks decode through

--- a/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
+++ b/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 15 Jun 2026 08:14:44 +0200
-Subject: [PATCH 14/17] ad_orender: render AC-3 through orender; fix
+Subject: [PATCH 14/18] ad_orender: render AC-3 through orender; fix
  channel-mode option
 
 - Offer the orender decoder for the `ac3` codec (in addition to truehd,

--- a/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
+++ b/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:25:41 +0200
-Subject: [PATCH 15/17] feat(ad_orender): keep the engine alive in host mode;
+Subject: [PATCH 15/18] feat(ad_orender): keep the engine alive in host mode;
  live spatial<->host
 
 ad_orender is now the persistent decoder for the supported codecs and

--- a/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
+++ b/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:35:47 +0200
-Subject: [PATCH 16/17] feat(ad_orender): hide the spatial overlay in host mode
+Subject: [PATCH 16/18] feat(ad_orender): hide the spatial overlay in host mode
 
 When routing channel audio to the native host decoder, suppress the whole
 spatial overlay (wireframe cube included) via orender_overlay_set_rendering(0)

--- a/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
+++ b/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 23:47:09 +0200
-Subject: [PATCH 17/17] feat(ad_orender): show Atmos profile, bed+objects and
+Subject: [PATCH 17/18] feat(ad_orender): show Atmos profile, bed+objects and
  DialNorm in track info
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
+++ b/patches/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
@@ -1,0 +1,129 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Fri, 19 Jun 2026 08:25:51 +0200
+Subject: [PATCH 18/18] fix(ad_orender): label track profile from decoded
+ objects, not is_spatial
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The track-info profile (shift+I / track list) drove the "+ Dolby Atmos"
+/ "DTS:X" suffix from orender_is_spatial(). For TrueHD that bridge probe
+just returns `presentation >= MAX_PRESENTATIONS - 1`, which is always
+true with the default presentation, so every TrueHD stream was labelled
+"Dolby TrueHD + Dolby Atmos" even when it carries no objects.
+
+is_spatial() can't simply be fixed: the CLI reads it pre-decode (before
+any packet) for its --enable-vbap guard, where real per-stream object
+detection is impossible, so it intentionally keeps "may contain objects"
+semantics. In the mpv path is_spatial() was only used here, cosmetically
+(routing uses orender_channel_mode()).
+
+Drive the label from the actually-decoded object count instead
+(object_count > 0), which the engine tracks via a sticky per-segment
+has_objects flag and is already what the "· N objects" suffix uses. Drop
+the now-dead is_spatial plumbing (per-frame FFI call, last_spatial cache
+key and field).
+
+Result: non-Atmos TrueHD → "Dolby TrueHD"; Atmos TrueHD →
+"Dolby TrueHD + Dolby Atmos · …+N objects · DialNorm …". E-AC3 JOC /
+plain (E-)AC3 / DTS labels unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 28 +++++++++++++---------------
+ 1 file changed, 13 insertions(+), 15 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index b8158efb65..d1e30ce118 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -130,7 +130,6 @@ struct priv {
+     const char *orender_desc;   // official-cased codec name (codec_desc literal)
+     char profile_buf[2][128];
+     int profile_slot;
+-    int last_spatial;
+     int last_objs;
+     int last_dnorm;
+     unsigned last_bed_sig;      // fingerprint of the bed labels (change detection)
+@@ -201,17 +200,20 @@ static const char *label_to_short_name(uint8_t lbl)
+ }
+ 
+ /* Human profile string for a codec, with/without object (Atmos/DTS:X) content —
+- * mirrors what ffmpeg reports on the native path so shift+I reads the same. */
+-static const char *profile_base(const char *codec, bool spatial)
++ * mirrors what ffmpeg reports on the native path so shift+I reads the same.
++ * `has_objects` reflects the actually-decoded object presence (object_count > 0),
++ * not the bridge's pre-decode "may be spatial" flag — a plain multichannel
++ * TrueHD/E-AC3 stream carries no objects and must not be labelled Atmos. */
++static const char *profile_base(const char *codec, bool has_objects)
+ {
+     if (strcmp(codec, "truehd") == 0)
+-        return spatial ? "Dolby TrueHD + Dolby Atmos" : "Dolby TrueHD";
++        return has_objects ? "Dolby TrueHD + Dolby Atmos" : "Dolby TrueHD";
+     if (strcmp(codec, "eac3") == 0)
+-        return spatial ? "Dolby Digital Plus + Dolby Atmos" : "Dolby Digital Plus";
++        return has_objects ? "Dolby Digital Plus + Dolby Atmos" : "Dolby Digital Plus";
+     if (strcmp(codec, "ac3") == 0)
+         return "Dolby Digital";
+     if (strcmp(codec, "dts") == 0)
+-        return spatial ? "DTS:X" : "DTS";
++        return has_objects ? "DTS:X" : "DTS";
+     return codec;
+ }
+ 
+@@ -223,7 +225,6 @@ static void refresh_codec_profile(struct priv *p)
+     if (!p->renderer)
+         return;
+ 
+-    int spatial = orender_is_spatial(p->renderer);    // 1 / 0 / <0
+     int objs    = orender_object_count(p->renderer);  // >=0 / -1
+     int dnorm   = orender_dialnorm_db(p->renderer);   // <=0 / INT32_MIN (unknown)
+ 
+@@ -235,15 +236,15 @@ static void refresh_codec_profile(struct priv *p)
+     for (uint32_t i = 0; i < bedn; i++)
+         bed_sig = (bed_sig ^ bed[i]) * 16777619u;
+ 
+-    if (spatial == p->last_spatial && objs == p->last_objs &&
+-        dnorm == p->last_dnorm && bed_sig == p->last_bed_sig)
++    if (objs == p->last_objs && dnorm == p->last_dnorm &&
++        bed_sig == p->last_bed_sig)
+         return;
+ 
+     int slot = p->profile_slot ^ 1;
+     char *buf = p->profile_buf[slot];
+     size_t cap = sizeof(p->profile_buf[slot]);
+ 
+-    int n = snprintf(buf, cap, "%s", profile_base(p->codec->codec, spatial == 1));
++    int n = snprintf(buf, cap, "%s", profile_base(p->codec->codec, objs > 0));
+     /* "· <bed labels>+<N> objects", e.g. "· LFE+11 objects" (no bed → "· N
+      * objects"). Only when there are objects (plain multichannel reports 0). */
+     if (objs > 0 && n > 0 && (size_t)n < cap) {
+@@ -259,7 +260,6 @@ static void refresh_codec_profile(struct priv *p)
+ 
+     p->codec->codec_profile = buf;   // atomic publish of the new slot
+     p->profile_slot = slot;
+-    p->last_spatial = spatial;
+     p->last_objs = objs;
+     p->last_dnorm = dnorm;
+     p->last_bed_sig = bed_sig;
+@@ -534,7 +534,6 @@ static void ad_orender_process(struct mp_filter *da)
+              * with its own strings; restore our desc and force the next frame to
+              * republish our profile (reset the cache to impossible sentinels). */
+             p->codec->codec_desc = p->orender_desc;
+-            p->last_spatial = -1;
+             p->last_objs = -1;
+             p->last_dnorm = 1;
+         } else {
+@@ -683,9 +682,8 @@ static struct mp_decoder *create(struct mp_filter *parent,
+         p->orender_desc = "TrueHD";
+     codec->codec_desc = p->orender_desc;
+ 
+-    /* Impossible sentinels (real: spatial 0/1, objs >=0, dnorm <=0 or INT32_MIN)
+-     * so the first decoded spatial frame always publishes a codec profile. */
+-    p->last_spatial = -1;
++    /* Impossible sentinels (real: objs >=0, dnorm <=0 or INT32_MIN) so the first
++     * decoded spatial frame always publishes a codec profile. */
+     p->last_objs = -1;
+     p->last_dnorm = 1;
+ 

--- a/src/ad_orender.c
+++ b/src/ad_orender.c
@@ -130,7 +130,6 @@ struct priv {
     const char *orender_desc;   // official-cased codec name (codec_desc literal)
     char profile_buf[2][128];
     int profile_slot;
-    int last_spatial;
     int last_objs;
     int last_dnorm;
     unsigned last_bed_sig;      // fingerprint of the bed labels (change detection)
@@ -201,17 +200,20 @@ static const char *label_to_short_name(uint8_t lbl)
 }
 
 /* Human profile string for a codec, with/without object (Atmos/DTS:X) content —
- * mirrors what ffmpeg reports on the native path so shift+I reads the same. */
-static const char *profile_base(const char *codec, bool spatial)
+ * mirrors what ffmpeg reports on the native path so shift+I reads the same.
+ * `has_objects` reflects the actually-decoded object presence (object_count > 0),
+ * not the bridge's pre-decode "may be spatial" flag — a plain multichannel
+ * TrueHD/E-AC3 stream carries no objects and must not be labelled Atmos. */
+static const char *profile_base(const char *codec, bool has_objects)
 {
     if (strcmp(codec, "truehd") == 0)
-        return spatial ? "Dolby TrueHD + Dolby Atmos" : "Dolby TrueHD";
+        return has_objects ? "Dolby TrueHD + Dolby Atmos" : "Dolby TrueHD";
     if (strcmp(codec, "eac3") == 0)
-        return spatial ? "Dolby Digital Plus + Dolby Atmos" : "Dolby Digital Plus";
+        return has_objects ? "Dolby Digital Plus + Dolby Atmos" : "Dolby Digital Plus";
     if (strcmp(codec, "ac3") == 0)
         return "Dolby Digital";
     if (strcmp(codec, "dts") == 0)
-        return spatial ? "DTS:X" : "DTS";
+        return has_objects ? "DTS:X" : "DTS";
     return codec;
 }
 
@@ -223,7 +225,6 @@ static void refresh_codec_profile(struct priv *p)
     if (!p->renderer)
         return;
 
-    int spatial = orender_is_spatial(p->renderer);    // 1 / 0 / <0
     int objs    = orender_object_count(p->renderer);  // >=0 / -1
     int dnorm   = orender_dialnorm_db(p->renderer);   // <=0 / INT32_MIN (unknown)
 
@@ -235,15 +236,15 @@ static void refresh_codec_profile(struct priv *p)
     for (uint32_t i = 0; i < bedn; i++)
         bed_sig = (bed_sig ^ bed[i]) * 16777619u;
 
-    if (spatial == p->last_spatial && objs == p->last_objs &&
-        dnorm == p->last_dnorm && bed_sig == p->last_bed_sig)
+    if (objs == p->last_objs && dnorm == p->last_dnorm &&
+        bed_sig == p->last_bed_sig)
         return;
 
     int slot = p->profile_slot ^ 1;
     char *buf = p->profile_buf[slot];
     size_t cap = sizeof(p->profile_buf[slot]);
 
-    int n = snprintf(buf, cap, "%s", profile_base(p->codec->codec, spatial == 1));
+    int n = snprintf(buf, cap, "%s", profile_base(p->codec->codec, objs > 0));
     /* "· <bed labels>+<N> objects", e.g. "· LFE+11 objects" (no bed → "· N
      * objects"). Only when there are objects (plain multichannel reports 0). */
     if (objs > 0 && n > 0 && (size_t)n < cap) {
@@ -259,7 +260,6 @@ static void refresh_codec_profile(struct priv *p)
 
     p->codec->codec_profile = buf;   // atomic publish of the new slot
     p->profile_slot = slot;
-    p->last_spatial = spatial;
     p->last_objs = objs;
     p->last_dnorm = dnorm;
     p->last_bed_sig = bed_sig;
@@ -534,7 +534,6 @@ static void ad_orender_process(struct mp_filter *da)
              * with its own strings; restore our desc and force the next frame to
              * republish our profile (reset the cache to impossible sentinels). */
             p->codec->codec_desc = p->orender_desc;
-            p->last_spatial = -1;
             p->last_objs = -1;
             p->last_dnorm = 1;
         } else {
@@ -683,9 +682,8 @@ static struct mp_decoder *create(struct mp_filter *parent,
         p->orender_desc = "TrueHD";
     codec->codec_desc = p->orender_desc;
 
-    /* Impossible sentinels (real: spatial 0/1, objs >=0, dnorm <=0 or INT32_MIN)
-     * so the first decoded spatial frame always publishes a codec profile. */
-    p->last_spatial = -1;
+    /* Impossible sentinels (real: objs >=0, dnorm <=0 or INT32_MIN) so the first
+     * decoded spatial frame always publishes a codec profile. */
     p->last_objs = -1;
     p->last_dnorm = 1;
 


### PR DESCRIPTION
Two changes so the **stable online build** picks up the recent ad_orender fix and gains NVIDIA hardware decoding.

## 1. Propagate the track-profile fix to patches/

release.yml builds upstream mpv `v0.41.0` + `patches/`, generated from the fork's `orender` branch. The fix (label the codec profile from the decoded object count instead of the always-true TrueHD `is_spatial` flag — so a non-Atmos TrueHD track no longer shows "+ Dolby Atmos") was on the fork but not yet exported. Cherry-picked onto `orender` and regenerated `patches/`: adds **0018**; the 0001-0017 changes are only the `[PATCH NN/total]` renumbering. `src/ad_orender.c` kept in sync.

## 2. Enable CUDA hwaccel in the released binaries

The Linux and Windows jobs never installed ffnvcodec, so mpv's `cuda-hwaccel` (auto) resolved to **disabled** — the shipped binary had no NVIDIA decode. Now each job installs nv-codec-headers (header-only; `libcuda`/`libnvcuvid` are dlopen'd at runtime, no CUDA SDK needed) and forces:
- Linux: `-Dcuda-hwaccel=enabled -Dcuda-interop=enabled`
- Windows (MinGW cross): `-Dcuda-hwaccel=enabled` (interop left at auto — the MinGW GL/D3D interop path is less certain to configure)

macOS is unchanged (no NVIDIA).

## Validation

YAML parses. The decode patch itself was built & smoke-tested locally on the fork. CI changes are only exercised when the release workflow runs on a `v*` tag — watch the first tagged release; if the Windows `cuda-hwaccel=enabled` can't configure against Martchus's mingw ffmpeg, we downgrade it to auto.

The master/FEL track (patches-master/) is handled separately on `feat/dv-fel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)