### PR TITLE
feat(fel): build CUDA hwaccel into the FEL mpv builds

### DIFF
--- a/.github/workflows/build-fel.yml
+++ b/.github/workflows/build-fel.yml
@@ -133,7 +133,9 @@ jobs:
           export LD_LIBRARY_PATH="$PREFIX/lib:${{ github.workspace }}/sysroot/usr/lib"
           export PATH="$PREFIX/bin:$PATH"
           cd "$MPV_DIR"
-          meson setup _b -Dorender=enabled
+          # cuda-hwaccel/-interop forced on: the FEL ffmpeg above is built with
+          # ffnvcodec, so NVIDIA decode is functional, not just compiled in.
+          meson setup _b -Dorender=enabled -Dcuda-hwaccel=enabled -Dcuda-interop=enabled
           meson compile -C _b
           echo "== mpv libplacebo linkage =="
           ldd _b/mpv | grep -E 'libplacebo|libavcodec' || true
@@ -252,6 +254,7 @@ jobs:
             /usr/x86_64-w64-mingw32/lib/libdovi*
             /usr/x86_64-w64-mingw32/include/libplacebo
             /usr/x86_64-w64-mingw32/include/libav*
+            /usr/x86_64-w64-mingw32/include/ffnvcodec
           key: fel-mingw-${{ needs.resolve-dvfel.outputs.sha }}-${{ hashFiles('deps-fel/**', 'scripts/build-fel-deps.sh') }}
 
       - name: Write meson cross-file (x86_64-w64-mingw32)
@@ -370,9 +373,11 @@ jobs:
       - name: Cross-compile mpv (MinGW, linked against FEL sysroot)
         run: |
           cd "$MPV_DIR"
+          # cuda-hwaccel forced on (FEL ffmpeg + nv-codec-headers provide nvdec);
+          # cuda-interop left at auto for the MinGW GL/D3D interop path.
           meson setup _b \
             --cross-file="$GITHUB_WORKSPACE/sysroot/mingw-cross.ini" \
-            -Dorender=enabled -Dlua=lua52 -Dasio=enabled -Dd3d11=enabled
+            -Dorender=enabled -Dlua=lua52 -Dasio=enabled -Dd3d11=enabled -Dcuda-hwaccel=enabled
           meson compile -C _b
 
       - name: Package (zip, DLL-walker bundles FEL DLLs from sysroot)

--- a/scripts/build-fel-deps.sh
+++ b/scripts/build-fel-deps.sh
@@ -124,6 +124,21 @@ log "libplacebo $pl_ver installed (sha=$PLACEBO_SHA)"
     echo "!! libplacebo $pl_ver lacks the FEL API (need >= 7.370 / PL_API_VER 367)" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
+# 2b. nv-codec-headers (ffnvcodec) — lets the ffmpeg below build NVIDIA nvdec/
+#     cuvid and lets the mpv build's cuda-hwaccel configure. Header-only;
+#     nvcuda/nvcuvid are dlopen'd at runtime, so no CUDA SDK is needed and the
+#     cross build works the same. Installs ffnvcodec.pc into $PREFIX/lib/pkgconfig
+#     (already first on PKG_CONFIG_PATH).
+# ---------------------------------------------------------------------------
+NVCODEC_REF=n13.0.19.0
+log "nv-codec-headers $NVCODEC_REF"
+if [ ! -d "$WORK/nv-codec-headers/.git" ]; then
+    git clone --depth 1 --branch "$NVCODEC_REF" \
+        https://github.com/FFmpeg/nv-codec-headers "$WORK/nv-codec-headers"
+fi
+make -C "$WORK/nv-codec-headers" install PREFIX="$PREFIX"
+
+# ---------------------------------------------------------------------------
 # 3. ffmpeg + dovi_split BSF (vendored patch).
 # ---------------------------------------------------------------------------
 log "ffmpeg $FFMPEG_REF + dovi_split"
@@ -139,7 +154,8 @@ for p in "$FFMPEG_PATCHES_DIR"/*.patch; do
 done
 
 ff_args=(--prefix="$PREFIX" --enable-shared --disable-static
-         --enable-gpl --enable-version3 --disable-doc)
+         --enable-gpl --enable-version3 --disable-doc
+         --enable-ffnvcodec --enable-nvdec --enable-cuvid)
 if [ "$CROSS" = 1 ]; then
     ff_args+=(--enable-cross-compile --cross-prefix="$CROSS_PREFIX"
               --arch=x86_64 --target-os=mingw32


### PR DESCRIPTION
Adds NVIDIA CUDA hardware decoding to the FEL builds, matching what #14 did for the stable release.

Unlike the stable build (which links apt/Martchus ffmpeg that already carries nvdec), the FEL build **compiles its own ffmpeg** (dovi_split) and links mpv against it. So just flipping mpv's `cuda-hwaccel` would compile but be **non-functional** — the FEL `libavcodec` had no nvdec. Two parts:

**`scripts/build-fel-deps.sh`** (self-contained, also used by the local FEL build):
- install nv-codec-headers (`n13.0.19.0`) into `$PREFIX` before ffmpeg
- configure ffmpeg with `--enable-ffnvcodec --enable-nvdec --enable-cuvid`

**`.github/workflows/build-fel.yml`**:
- Linux mpv: `-Dcuda-hwaccel=enabled -Dcuda-interop=enabled`
- Windows (MinGW cross) mpv: `-Dcuda-hwaccel=enabled` (interop left at auto)
- add `include/ffnvcodec` to the MinGW dep cache so cache-hit runs keep the header for the mpv build

Editing `build-fel-deps.sh` busts the FEL deps cache (its hash is in the cache key), so the next run rebuilds ffmpeg with nvdec. `nvcuda`/`nvcuvid` are dlopen'd at runtime — no CUDA SDK at build time, cross included.

## Validation
`build-fel.yml` parses (YAML), `build-fel-deps.sh` passes `bash -n`. Only exercised when the FEL workflow runs (cron / `workflow_dispatch` / `v*-fel*` tag) — watch the first run; if `--enable-nvdec`/`--enable-cuvid` can't configure against this ffmpeg ref, drop to `--enable-ffnvcodec` alone (auto-enables nvdec), and if the Windows `cuda-hwaccel` can't configure, set it to auto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)