### PR TITLE
feat(release): enable VA-API (AMD/Intel) hardware decoding on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
           sudo apt-get install -y \
             meson ninja-build pkg-config gcc \
             libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libswscale-dev \
-            libass-dev libplacebo-dev liblua5.2-dev libx11-dev
+            libass-dev libplacebo-dev liblua5.2-dev libx11-dev \
+            libva-dev libdrm-dev
 
       - name: Checkout Omniphony (renderer source)
         uses: actions/checkout@v4
@@ -98,9 +99,13 @@ jobs:
           export PKG_CONFIG_PATH="${{ github.workspace }}/sysroot/usr/lib/pkgconfig"
           export LD_LIBRARY_PATH="${{ github.workspace }}/sysroot/usr/lib"
           cd "build/mpv-${MPV_TAG}"
-          # cuda-hwaccel/-interop forced on so the released binary always carries
-          # NVIDIA hardware decoding (ffnvcodec provided by the step above).
-          meson setup _b -Dorender=enabled -Dcuda-hwaccel=enabled -Dcuda-interop=enabled
+          # cuda-hwaccel/-interop: NVIDIA hardware decoding (ffnvcodec above).
+          # vaapi: AMD/Intel hardware decoding (VA-API) — apt's ffmpeg already
+          # carries vaapi, so libva-dev/libdrm-dev above is all mpv needs.
+          # (No -Dvulkan hwdec here: it needs ffmpeg >= 7.0 and apt ships 6.x.)
+          meson setup _b -Dorender=enabled \
+            -Dcuda-hwaccel=enabled -Dcuda-interop=enabled \
+            -Dvaapi=enabled
           meson compile -C _b
 
       - name: Package (zip)


### PR DESCRIPTION
The AMD/Intel counterpart to the CUDA change (ROCm is GPU *compute*, not video decode — the AMD/Intel decode path is **VA-API**).

The Linux release binary had **no** AMD/Intel hardware decode: the job never installed libva, so mpv's `vaapi` (auto) resolved to **disabled** and Linux AMD/Intel users got software-only decode. (It looked fine locally only because dev machines have libva.)

- Install `libva-dev libdrm-dev`
- Force `-Dvaapi=enabled` (apt's ffmpeg already carries vaapi, so that's all mpv needs)

**Windows** already covers AMD/Intel/NVIDIA via D3D11VA (`-Dd3d11=enabled`) — no change.

**Vulkan video decode** is intentionally NOT enabled here: it requires ffmpeg ≥ 7.0 and ubuntu-latest ships 6.x, so the flag would be a no-op. The FEL build (custom ffmpeg 8.1) gets Vulkan decode in a separate PR on `feat/dv-fel`.

YAML validated. Exercised only when the release runs on a `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)