### PR TITLE
feat(fel): enable VA-API + Vulkan video decode in the FEL builds

### DIFF
--- a/.github/workflows/build-fel.yml
+++ b/.github/workflows/build-fel.yml
@@ -58,7 +58,8 @@ jobs:
           sudo apt-get install -y \
             meson ninja-build pkg-config gcc nasm git patchelf zlib1g-dev \
             libass-dev liblua5.2-dev libx11-dev \
-            libvulkan-dev libshaderc-dev glslang-dev liblcms2-dev
+            libvulkan-dev libshaderc-dev glslang-dev liblcms2-dev \
+            libva-dev libdrm-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -133,9 +134,14 @@ jobs:
           export LD_LIBRARY_PATH="$PREFIX/lib:${{ github.workspace }}/sysroot/usr/lib"
           export PATH="$PREFIX/bin:$PATH"
           cd "$MPV_DIR"
-          # cuda-hwaccel/-interop forced on: the FEL ffmpeg above is built with
-          # ffnvcodec, so NVIDIA decode is functional, not just compiled in.
-          meson setup _b -Dorender=enabled -Dcuda-hwaccel=enabled -Dcuda-interop=enabled
+          # Hardware decoding forced on, all functional because the FEL ffmpeg
+          # above is built with the matching support:
+          #   cuda-hwaccel/-interop -> NVIDIA (ffnvcodec)
+          #   vaapi                 -> AMD/Intel (VA-API)
+          #   vulkan                -> Vulkan video decode (ffmpeg 8.1, vendor-neutral)
+          meson setup _b -Dorender=enabled \
+            -Dcuda-hwaccel=enabled -Dcuda-interop=enabled \
+            -Dvaapi=enabled -Dvulkan=enabled
           meson compile -C _b
           echo "== mpv libplacebo linkage =="
           ldd _b/mpv | grep -E 'libplacebo|libavcodec' || true

--- a/scripts/build-fel-deps.sh
+++ b/scripts/build-fel-deps.sh
@@ -160,6 +160,11 @@ if [ "$CROSS" = 1 ]; then
     ff_args+=(--enable-cross-compile --cross-prefix="$CROSS_PREFIX"
               --arch=x86_64 --target-os=mingw32
               --pkg-config="$PKGCONFIG")
+else
+    # Native (Linux): AMD/Intel hwdec (VA-API) + Vulkan video decode (ffmpeg
+    # 8.1 supports it; needs libva/libvulkan at configure time). Windows uses
+    # D3D11VA / nvdec instead, so these are native-only.
+    ff_args+=(--enable-vaapi --enable-vulkan)
 fi
 ( cd "$WORK/ffmpeg" && ./configure "${ff_args[@]}" )
 make -C "$WORK/ffmpeg" -j"$JOBS"


### PR DESCRIPTION
Completes GPU decode coverage for the FEL track (companion to #17, which added VA-API to the stable Linux release).

The FEL build links mpv against its **own ffmpeg (release/8.1)**, so AMD/Intel (VA-API) and vendor-neutral **Vulkan video decode** need that ffmpeg built with the support — not just mpv's flag. Vulkan decode is viable here precisely because the FEL ffmpeg is 8.1 (the stable build's apt ffmpeg 6.x can't, which is why #17 was VA-API only).

- **build-fel-deps.sh**: native ffmpeg gains `--enable-vaapi --enable-vulkan` (native-only; the MinGW/Windows cross build uses D3D11VA / nvdec).
- **build-fel.yml** (Linux): install `libva-dev libdrm-dev`; mpv forced with `-Dvaapi=enabled -Dvulkan=enabled` (libvulkan-dev already present).

Windows unchanged (D3D11VA via `-Dd3d11=enabled`). libva/libvulkan are runtime system libs, so nothing extra is bundled. Editing build-fel-deps.sh busts the FEL deps cache → next run rebuilds ffmpeg with vaapi/vulkan.

## Validation
YAML valid, `bash -n` OK. Only exercised when the FEL workflow runs. Watch the first run: if `--enable-vulkan` needs an extra dep against this ffmpeg ref, adjust; VA-API is the solid path regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)