### PR TITLE
fix(release): install libegl/libgl for Linux VA-API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             meson ninja-build pkg-config gcc \
             libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libswscale-dev \
             libass-dev libplacebo-dev liblua5.2-dev libx11-dev \
-            libva-dev libdrm-dev
+            libva-dev libdrm-dev libegl-dev libgl-dev
 
       - name: Checkout Omniphony (renderer source)
         uses: actions/checkout@v4


### PR DESCRIPTION
The v0.4.1 Linux release build failed: `meson: Feature vaapi cannot be enabled`
(`egl found: NO`). `-Dvaapi=enabled` was added in 16017f7 but the runner lacked an
EGL dev package. Add `libegl-dev` + `libgl-dev` to the Linux build deps so VA-API
(and its egl path) configures. macOS / Windows jobs were unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)