### PR TITLE
fix(release): -Dvaapi=auto for the Linux bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           # (No -Dvulkan hwdec here: it needs ffmpeg >= 7.0 and apt ships 6.x.)
           meson setup _b -Dorender=enabled \
             -Dcuda-hwaccel=enabled -Dcuda-interop=enabled \
-            -Dvaapi=enabled
+            -Dvaapi=auto
           meson compile -C _b
 
       - name: Package (zip)


### PR DESCRIPTION
vaapi=enabled hard-fails (its GL-context sub-features aren't wired in this build). Use auto so the Linux bundle builds (vaapi included if sub-deps resolve, else skipped, as in pre-0.4.1 releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)