### PR TITLE
ci(fel): enable Blu-ray/DVD/ISO disc playback in FEL builds (#25)

### DIFF
--- a/.github/workflows/build-fel.yml
+++ b/.github/workflows/build-fel.yml
@@ -59,7 +59,8 @@ jobs:
             meson ninja-build pkg-config gcc nasm git patchelf zlib1g-dev \
             libass-dev liblua5.2-dev libx11-dev \
             libvulkan-dev libshaderc-dev glslang-dev liblcms2-dev \
-            libva-dev libdrm-dev
+            libva-dev libdrm-dev \
+            libbluray-dev libdvdnav-dev libdvdread-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -141,7 +142,8 @@ jobs:
           #   vulkan                -> Vulkan video decode (ffmpeg 8.1, vendor-neutral)
           meson setup _b -Dorender=enabled \
             -Dcuda-hwaccel=enabled -Dcuda-interop=enabled \
-            -Dvaapi=auto -Dvulkan=enabled
+            -Dvaapi=auto -Dvulkan=enabled \
+            -Dlibbluray=enabled -Ddvdnav=enabled
           meson compile -C _b
           echo "== mpv libplacebo linkage =="
           ldd _b/mpv | grep -E 'libplacebo|libavcodec' || true
@@ -192,7 +194,8 @@ jobs:
           # libdovi (so build-fel-deps.sh skips its own `cargo install cargo-c`).
           brew install meson ninja pkg-config cargo-c \
             libass luajit lcms2 shaderc glslang \
-            molten-vk vulkan-headers vulkan-loader
+            molten-vk vulkan-headers vulkan-loader \
+            libbluray libdvdnav libdvdread
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -268,7 +271,10 @@ jobs:
           export PATH="$PREFIX/bin:$PATH"
           cd "$MPV_DIR"
           # No CUDA/VA-API on macOS; Vulkan -> MoltenVK is the gpu-next path.
-          meson setup _b -Dorender=enabled -Dvulkan=enabled
+          # libbluray/dvdnav (BD/DVD/ISO) from brew; the recursive dylib bundler
+          # in the packaging step picks them up into the self-contained zip.
+          meson setup _b -Dorender=enabled -Dvulkan=enabled \
+            -Dlibbluray=enabled -Ddvdnav=enabled
           meson compile -C _b
           echo "== mpv libplacebo linkage =="
           otool -L _b/mpv | grep -E 'libplacebo|libavcodec' || true
@@ -409,7 +415,12 @@ jobs:
             mingw-w64-meson \
             mingw-w64-libass \
             mingw-w64-vulkan-headers mingw-w64-vulkan-icd-loader \
-            mingw-w64-shaderc mingw-w64-spirv-cross mingw-w64-lcms2 mingw-w64-zlib
+            mingw-w64-shaderc mingw-w64-spirv-cross mingw-w64-lcms2 mingw-w64-zlib \
+            mingw-w64-libdvdnav mingw-w64-libdvdread
+          # ^ DVD playback (folder + ISO) from Martchus; libdvdnav -> libdvdread
+          # read images natively. libbluray is built from source with embedded
+          # libudfread in a later step (Martchus's lacks udfread = BD folders
+          # only); the DLL-walker in packaging bundles them all.
           # We build our OWN libplacebo (dv-fel) + ffmpeg (dovi_split) into the
           # MinGW sysroot below, so we intentionally do NOT install
           # mingw-w64-libplacebo / mingw-w64-ffmpeg here.
@@ -527,6 +538,15 @@ jobs:
           Cflags: -I\${includedir}
           EOF
 
+      - name: Build & install libbluray with BD-ISO (libudfread) support
+        run: |
+          # Martchus ships libbluray without libudfread (BD folders only). Build
+          # it from source with the vendored udfread embedded so raw BD ISOs
+          # open; installs over the MinGW sysroot the mpv build below links to.
+          # The cross-file was written above (Write meson cross-file step).
+          CROSS_FILE="$GITHUB_WORKSPACE/sysroot/mingw-cross.ini" \
+            bash scripts/build-libbluray-mingw.sh
+
       - name: Download liborender (built from source)
         uses: actions/download-artifact@v4
         with:
@@ -565,7 +585,8 @@ jobs:
           # cuda-interop left at auto for the MinGW GL/D3D interop path.
           meson setup _b \
             --cross-file="$GITHUB_WORKSPACE/sysroot/mingw-cross.ini" \
-            -Dorender=enabled -Dlua=lua52 -Dasio=enabled -Dd3d11=enabled -Dcuda-hwaccel=enabled
+            -Dorender=enabled -Dlua=lua52 -Dasio=enabled -Dd3d11=enabled -Dcuda-hwaccel=enabled \
+            -Dlibbluray=enabled -Ddvdnav=enabled
           meson compile -C _b
 
       - name: Package (zip, DLL-walker bundles FEL DLLs from sysroot)

--- a/scripts/build-libbluray-mingw.sh
+++ b/scripts/build-libbluray-mingw.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build libbluray from source into the MinGW cross sysroot, WITH its vendored
+# libudfread (BD-ISO / UDF image support) statically embedded.
+#
+# Why this exists: the Martchus prebuilt `mingw-w64-libbluray` is compiled
+# without libudfread, so it can only read Blu-ray *folders* (an extracted
+# BDMV/), not raw .iso images. libbluray 1.4.x bundles libudfread under
+# contrib/ and its meson build falls back to that subproject when no system
+# libudfread is found, linking it statically (embed_udfread=true). The result
+# is a single libbluray DLL that opens BD ISOs, with no extra DLL to bundle.
+#
+# Use: drop `mingw-w64-libbluray` from the pacman install and run this instead.
+# It installs over the same MinGW prefix, so mpv's meson finds it via
+# pkg-config. libdvdnav/libdvdread (DVD, incl. ISO) still come from Martchus —
+# they read disc images natively and need no rebuild.
+#
+# Env:
+#   CROSS_FILE      meson cross-file for x86_64-w64-mingw32 (required)
+#   SYS             MinGW sysroot / install prefix (default /usr/x86_64-w64-mingw32)
+#   LIBBLURAY_VER   libbluray release to build (default 1.4.1, matches Martchus)
+set -euo pipefail
+
+: "${CROSS_FILE:?set CROSS_FILE to the meson mingw cross-file}"
+SYS="${SYS:-/usr/x86_64-w64-mingw32}"
+LIBBLURAY_VER="${LIBBLURAY_VER:-1.4.1}"
+HOST=x86_64-w64-mingw32
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+
+url="https://download.videolan.org/pub/videolan/libbluray/${LIBBLURAY_VER}/libbluray-${LIBBLURAY_VER}.tar.xz"
+echo ">> fetching $url"
+curl -fsSL -o libbluray.tar.xz "$url"
+tar xf libbluray.tar.xz
+cd "libbluray-${LIBBLURAY_VER}"
+
+# default_library=shared    -> ship libbluray as a DLL (mpv links it dynamically)
+# embed_udfread=true (default) -> vendored libudfread linked statically into the DLL
+# bdj_jar=disabled          -> no BD-J Java menus (no JDK in CI; A/V playback only)
+# enable_tools=false        -> skip the bd_info/etc. CLI tools we don't ship
+# fontconfig/freetype/libxml2 stay at auto: resolved from $SYS via the cross
+# pkg-config named in CROSS_FILE (fontconfig auto-disables on Windows by design).
+meson setup _b \
+  --cross-file "$CROSS_FILE" \
+  --prefix "$SYS" \
+  --libdir lib \
+  --buildtype release \
+  -Ddefault_library=shared \
+  -Dbdj_jar=disabled \
+  -Denable_tools=false
+meson compile -C _b
+meson install -C _b
+
+# `meson setup` above would already have failed if libudfread were unavailable
+# (the dependency() call is not optional). Assert the DLL + .pc actually landed
+# so the mpv build that follows finds them.
+dll="$(ls "$SYS"/bin/libbluray*.dll 2>/dev/null | head -1 || true)"
+test -n "$dll" || { echo "!! libbluray DLL not installed into $SYS/bin" >&2; exit 1; }
+"${HOST}-pkg-config" --exists libbluray \
+  || { echo "!! libbluray.pc not visible to the MinGW pkg-config" >&2; exit 1; }
+echo "OK: installed $(basename "$dll") (libbluray ${LIBBLURAY_VER} + embedded libudfread, BD-ISO enabled)"


### PR DESCRIPTION
## What

FEL/master-track companion to #26 — enables Blu-ray / DVD playback (discs, folders, ISO) in the Dolby Vision FEL builds. `build-fel.yml` lives only on `feat/dv-fel`, so this targets that branch directly.

## Changes

Same treatment as the stable track, across all three FEL jobs:

| Platform | deps | meson |
|---|---|---|
| Linux (apt) | `libbluray-dev libdvdnav-dev libdvdread-dev` | `-Dlibbluray=enabled -Ddvdnav=enabled` |
| macOS (brew) | `libbluray libdvdnav libdvdread` | same |
| Windows | `libdvdnav`/`libdvdread` from Martchus; **libbluray built from source** | same |

Windows BD-ISO uses the shared **`scripts/build-libbluray-mingw.sh`** (libbluray 1.4.x with its embedded `libudfread`), since the Martchus prebuilt libbluray lacks udfread. On macOS the recursive FEL dylib bundler already pulls `libbluray`/`libudfread` into the self-contained zip.

## Branch note

`scripts/build-libbluray-mingw.sh` is identical to the one in #26. It's included here too so `feat/dv-fel` stays self-consistent (the Windows step references it) until #26 reaches `main` and `main` is merged up. Identical content → the eventual merge-up is conflict-free.

## Validation

Same as #26: YAML validated and upstream facts verified; the from-source MinGW libbluray build and real BD-ISO playback prove out on the first CI run / with a real disc.

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
