### PR TITLE
ci(fel): fix MoltenVK ICD path on macOS

### DIFF
--- a/.github/workflows/build-fel.yml
+++ b/.github/workflows/build-fel.yml
@@ -335,10 +335,13 @@ jobs:
 
           # MoltenVK ICD pointing at the bundled driver (relative to the json dir).
           # Users export VK_ICD_FILENAMES to this file (documented in the release).
+          # Homebrew installs the ICD under etc/ (not share/) and the path has
+          # drifted before, so locate it with find rather than hardcoding.
           mkdir -p staging/share/vulkan/icd.d
+          icd_src=$(find -L "$(brew --prefix molten-vk)" -name MoltenVK_icd.json 2>/dev/null | head -1)
+          test -n "$icd_src" || { echo "!! MoltenVK_icd.json not found under molten-vk prefix" >&2; exit 1; }
           sed 's#"library_path"[[:space:]]*:[[:space:]]*"[^"]*"#"library_path": "../../../libMoltenVK.dylib"#' \
-            "$(brew --prefix molten-vk)/share/vulkan/icd.d/MoltenVK_icd.json" \
-            > staging/share/vulkan/icd.d/MoltenVK_icd.json
+            "$icd_src" > staging/share/vulkan/icd.d/MoltenVK_icd.json
 
           # Gate: nothing must still link an absolute brew/local path.
           leak=$(for f in staging/mpv staging/*.dylib; do


### PR DESCRIPTION
FEL companion to #29. The FEL macOS job read the MoltenVK ICD from `share/vulkan/icd.d`, but Homebrew installs it under `etc/vulkan/icd.d` — the `sed` failed on the missing file and killed the job. Locate the ICD with `find` instead (robust to the layout drift). The FEL job already copies `libMoltenVK.dylib` explicitly, so only the path needed fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)