### PR TITLE
ci(macos): normalise bundled libMoltenVK id to @rpath

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -438,8 +438,13 @@ jobs:
 
           # MoltenVK is dlopen'd by the Vulkan loader via its ICD, not a link-time
           # dep, so the recursive walker never sees it — copy it explicitly and
-          # seed the worklist with it so its id/rpath get normalised too.
+          # seed the worklist with it. Its brew install id is an absolute path
+          # (otool -L line 2), which the leak gate rejects, so normalise it to
+          # @rpath up front like liborender (the worklist only rewrites a seed's
+          # dependencies, never its own id).
           cp "$(brew --prefix molten-vk)/lib/libMoltenVK.dylib" staging/
+          chmod u+w staging/libMoltenVK.dylib
+          install_name_tool -id @rpath/libMoltenVK.dylib staging/libMoltenVK.dylib
           worklist=(staging/mpv staging/liborender.dylib staging/libMoltenVK.dylib)
           while [ ${#worklist[@]} -gt 0 ]; do
             obj="${worklist[0]}"; worklist=("${worklist[@]:1}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -564,8 +564,13 @@ jobs:
 
           # MoltenVK is dlopen'd by the Vulkan loader via its ICD, not a link-time
           # dep, so the recursive walker never sees it — copy it explicitly and
-          # seed the worklist with it so its id/rpath get normalised too.
+          # seed the worklist with it. Its brew install id is an absolute path
+          # (otool -L line 2), which the leak gate rejects, so normalise it to
+          # @rpath up front like liborender (the worklist only rewrites a seed's
+          # dependencies, never its own id).
           cp "$(brew --prefix molten-vk)/lib/libMoltenVK.dylib" staging/
+          chmod u+w staging/libMoltenVK.dylib
+          install_name_tool -id @rpath/libMoltenVK.dylib staging/libMoltenVK.dylib
           worklist=(staging/mpv staging/liborender.dylib staging/libMoltenVK.dylib)
           while [ ${#worklist[@]} -gt 0 ]; do
             obj="${worklist[0]}"; worklist=("${worklist[@]:1}")


### PR DESCRIPTION
Follow-up to #29. The re-run macOS Package step got past the ICD fix but failed the leak gate on `/opt/homebrew/opt/molten-vk/lib/libMoltenVK.dylib` — that path is the bundled dylib's own **install id** (`otool -L` line 2, which the gate's `NR>1` scan includes). The recursive worklist rewrites a seed's *dependencies* but never its own id, so normalise libMoltenVK's id to `@rpath` right after copying, mirroring how `liborender.dylib` is handled. Applies to release.yml + integration-build.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)