### PR TITLE
ci(fel): cache libsw* headers (fix Windows mpv compile)

### DIFF
--- a/.github/workflows/build-fel.yml
+++ b/.github/workflows/build-fel.yml
@@ -460,8 +460,13 @@ jobs:
             /usr/x86_64-w64-mingw32/lib/libdovi*
             /usr/x86_64-w64-mingw32/include/libplacebo
             /usr/x86_64-w64-mingw32/include/libav*
+            /usr/x86_64-w64-mingw32/include/libsw*
             /usr/x86_64-w64-mingw32/include/ffnvcodec
-          key: fel-mingw-${{ needs.resolve-dvfel.outputs.sha }}-${{ hashFiles('deps-fel/**', 'scripts/build-fel-deps.sh') }}
+          # v2: previous key cached the libsw* libs + .pc but not their headers
+          # (the include/libav* glob misses libswresample/libswscale), so a cache
+          # hit left mpv unable to find <libswresample/swresample.h>. Bump to
+          # rebuild + recache the prefix with those headers included.
+          key: fel-mingw-v2-${{ needs.resolve-dvfel.outputs.sha }}-${{ hashFiles('deps-fel/**', 'scripts/build-fel-deps.sh') }}
 
       - name: Write meson cross-file (x86_64-w64-mingw32)
         run: |


### PR DESCRIPTION
FEL beta.4 Windows mpv compile failed: `fatal error: libswresample/swresample.h: No such file`. The MinGW dep cache globs `include/libav*` but not `include/libsw*`, so swresample/swscale **headers** were never cached — on a cache hit the prefix had the libs + `.pc` (meson found libswresample 6.3.102) but not the header. Add `include/libsw*` and bump the cache key (v2) to rebuild + recache.

Latent pre-existing bug (only triggers on a cache hit; beta.3 built fresh). Unrelated to disc playback — note the same run confirmed **libbluray built + BD-ISO enabled on FEL Windows**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)