### PR TITLE
ci(macos): build the .app with mpv's native macos-bundle (#22)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,9 +568,14 @@ jobs:
             || { echo "!! libMoltenVK.dylib not bundled" >&2; exit 1; }
           test -f mpv-omniphony.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json \
             || { echo "!! MoltenVK ICD not bundled" >&2; exit 1; }
+          # The bundled libMoltenVK keeps its brew install *id* (otool line 2);
+          # that's by design — it's dlopen'd via the ICD's relative library_path,
+          # never linked — so exclude that one self-reference. Any OTHER absolute
+          # brew/local path would be a real un-relocated dependency.
           leak=$(find mpv-omniphony.app -type f \( -name '*.dylib' -o -name mpv \) -print0 \
                  | xargs -0 -I{} sh -c 'otool -L "{}" | awk "NR>1{print \$1}"' \
-                 | grep -E '^/(opt/homebrew|usr/local)' | sort -u || true)
+                 | grep -E '^/(opt/homebrew|usr/local)' \
+                 | grep -v '/libMoltenVK\.dylib$' | sort -u || true)
           [ -z "$leak" ] || { echo "!! un-bundled absolute references remain:" >&2; echo "$leak" >&2; exit 1; }
           codesign --verify --deep --strict mpv-omniphony.app || true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,163 +515,73 @@ jobs:
 
       - name: Build mpv with ad_orender
         run: |
-          # Prepend our sysroot, then Homebrew's pkgconfig so meson finds both
-          # liborender and the brew-installed ffmpeg/libass/libplacebo/luajit.
-          export PKG_CONFIG_PATH="${{ github.workspace }}/sysroot/usr/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          # Prepend our sysroot, then Homebrew's pkgconfig (incl. vulkan-loader)
+          # so meson finds liborender + the brew ffmpeg/libass/libplacebo/luajit
+          # and the Vulkan loader. cocoa/swift/vulkan are auto-on here; force them
+          # so the GUI + Vulkan(MoltenVK) display stack is built and a silent
+          # disable becomes a loud failure (no-video bundles are the whole bug).
+          export PKG_CONFIG_PATH="${{ github.workspace }}/sysroot/usr/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
           cd "build/mpv-${MPV_TAG}"
-          # Disc playback (BD/DVD/ISO) via the brew libbluray/libdvdnav installed
-          # above. brew's libbluray pulls libudfread, so raw BD-ISO works too;
-          # the recursive dylib worklist in the packaging step bundles them all
-          # into the self-contained zip (no runtime brew dependency).
-          meson setup _b -Dorender=enabled -Dlibbluray=enabled -Ddvdnav=enabled
+          # Disc playback (BD/DVD/ISO) via brew libbluray (pulls libudfread → raw
+          # BD-ISO) + libdvdnav. mpv's own macos-bundle target relocates these and
+          # every other dylib in the next step.
+          meson setup _b -Dorender=enabled -Dlibbluray=enabled -Ddvdnav=enabled \
+            -Dcocoa=enabled -Dswift-build=enabled -Dvulkan=enabled
           meson compile -C _b
 
-      - name: Package (zip)
-        # Self-contained bundle: copy every non-system dylib mpv depends on (the
-        # brew ffmpeg/libass/libplacebo/luajit + their transitive deps + the
-        # Vulkan loader/MoltenVK) next to the binary and rewrite the references to
-        # @rpath, so the artifact does not link the user's (possibly different)
-        # Homebrew libs at runtime — that mismatch is what produced
-        # "libavcodec: build version X incompatible with runtime version Y".
-        # This is the macOS analogue of the Windows recursive DLL worklist above.
+      - name: Bundle into mpv.app (mpv's native macos-bundle)
         run: |
-          mkdir -p staging
-          cp "build/mpv-${MPV_TAG}/_b/mpv" staging/
-          cp sysroot/usr/lib/liborender.dylib staging/
-          cp sysroot/usr/include/orender.h staging/
-          cp README.md staging/
+          # Use mpv's upstream TOOLS/osxbundle.py + dylib_unhell.py instead of a
+          # hand-rolled bundler: it relocates every non-system dylib (incl.
+          # liborender + the whole brew ffmpeg/libass/libplacebo stack) into
+          # Contents/MacOS/lib, and its process_vulkan_loader() copies libMoltenVK
+          # into Contents/Frameworks and writes a CORRECT ICD into
+          # Contents/Resources/vulkan/icd.d (library_path relative to Frameworks).
+          # This is what makes the app genuinely self-contained — mpv loads its
+          # OWN bundled ffmpeg, fixing the "libavcodec build vs runtime" mismatch
+          # (#22). Same PKG_CONFIG_PATH as the build so dylib_unhell's optional
+          # `pkg-config vulkan` probe resolves.
+          export PKG_CONFIG_PATH="${{ github.workspace }}/sysroot/usr/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          cd "build/mpv-${MPV_TAG}"
+          meson compile -C _b macos-bundle   # -> _b/mpv.app (category 'video')
 
-          # liborender first: normalise its id and repoint mpv's reference, so the
-          # recursive pass below treats it as already-bundled (older OMNIPHONY_REFs
-          # lack the @rpath id on the dylib itself).
-          install_name_tool -id @rpath/liborender.dylib staging/liborender.dylib
-          old_ref=$(otool -L staging/mpv | awk '/liborender\.dylib/ {print $1; exit}')
-          if [ -n "$old_ref" ] && [ "$old_ref" != "@rpath/liborender.dylib" ]; then
-            install_name_tool -change "$old_ref" @rpath/liborender.dylib staging/mpv
-          fi
+      - name: Brand, verify and package the .app
+        run: |
+          cd "build/mpv-${MPV_TAG}/_b"
+          mv mpv.app mpv-omniphony.app
+          # osxbundle's Info.plist template hardcodes io.mpv/mpv; rebrand, then
+          # re-sign (editing the plist invalidates the ad-hoc signature). The
+          # inner executable stays `mpv`; only the bundle dir is renamed.
+          PB=/usr/libexec/PlistBuddy
+          "$PB" -c "Set :CFBundleIdentifier fr.mgth.mpv-omniphony" mpv-omniphony.app/Contents/Info.plist
+          "$PB" -c "Set :CFBundleName mpv-omniphony"               mpv-omniphony.app/Contents/Info.plist
+          "$PB" -c "Add :CFBundleDisplayName string mpv-omniphony" mpv-omniphony.app/Contents/Info.plist 2>/dev/null || true
+          codesign --force --deep --sign - mpv-omniphony.app
 
-          # OS-provided libs we must NOT bundle; everything else (brew, /usr/local,
-          # a Cellar path) is copied. Already-@-relative refs are skipped.
-          is_system() {
-            case "$1" in
-              /usr/lib/*|/System/*|@*) return 0 ;;
-            esac
-            return 1
-          }
-          # Resolve a brew opt/Cellar symlink chain to the real dylib so we copy a
-          # real file, not a dangling link; key the bundle by basename.
-          resolve() { python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"; }
+          # Smoke test — all the headless runner can do: binary loads, Vulkan is
+          # listed, MoltenVK + ICD are bundled, and no residual absolute brew path
+          # remains (the old leak gate, kept).
+          ./mpv-omniphony.app/Contents/MacOS/mpv --version
+          ./mpv-omniphony.app/Contents/MacOS/mpv --gpu-api=help | grep -qi vulkan \
+            || echo "!! warning: vulkan gpu-api not listed (MoltenVK detection?)" >&2
+          test -f mpv-omniphony.app/Contents/Frameworks/libMoltenVK.dylib \
+            || { echo "!! libMoltenVK.dylib not bundled" >&2; exit 1; }
+          test -f mpv-omniphony.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json \
+            || { echo "!! MoltenVK ICD not bundled" >&2; exit 1; }
+          leak=$(find mpv-omniphony.app -type f \( -name '*.dylib' -o -name mpv \) -print0 \
+                 | xargs -0 -I{} sh -c 'otool -L "{}" | awk "NR>1{print \$1}"' \
+                 | grep -E '^/(opt/homebrew|usr/local)' | sort -u || true)
+          [ -z "$leak" ] || { echo "!! un-bundled absolute references remain:" >&2; echo "$leak" >&2; exit 1; }
+          codesign --verify --deep --strict mpv-omniphony.app || true
 
-          # MoltenVK is dlopen'd by the Vulkan loader via its ICD, not a link-time
-          # dep, so the recursive walker never sees it — copy it explicitly and
-          # seed the worklist with it. Its brew install id is an absolute path
-          # (otool -L line 2), which the leak gate rejects, so normalise it to
-          # @rpath up front like liborender (the worklist only rewrites a seed's
-          # dependencies, never its own id).
-          cp "$(brew --prefix molten-vk)/lib/libMoltenVK.dylib" staging/
-          chmod u+w staging/libMoltenVK.dylib
-          install_name_tool -id @rpath/libMoltenVK.dylib staging/libMoltenVK.dylib
-          worklist=(staging/mpv staging/liborender.dylib staging/libMoltenVK.dylib)
-          while [ ${#worklist[@]} -gt 0 ]; do
-            obj="${worklist[0]}"; worklist=("${worklist[@]:1}")
-            echo "scanning $obj"
-            # otool -L line 1 is the object's own id; deps start at NR>1.
-            while read -r ref; do
-              is_system "$ref" && continue
-              base=$(basename "$ref")
-              if [ ! -f "staging/$base" ]; then
-                real=$(resolve "$ref")
-                if [ -f "$real" ]; then
-                  cp "$real" "staging/$base"
-                  chmod u+w "staging/$base"
-                  install_name_tool -id "@rpath/$base" "staging/$base"
-                  worklist+=("staging/$base")
-                  echo "  + $base"
-                else
-                  echo "  ! NOT FOUND: $ref"
-                fi
-              fi
-              install_name_tool -change "$ref" "@rpath/$base" "$obj" 2>/dev/null || true
-            done < <(otool -L "$obj" | awk 'NR>1 {print $1}')
-          done
-
-          # Each object resolves @rpath against its own directory.
-          for f in staging/*.dylib; do
-            install_name_tool -add_rpath @loader_path "$f" 2>/dev/null || true
-          done
-          install_name_tool -add_rpath @loader_path staging/mpv 2>/dev/null || true
-          install_name_tool -add_rpath @executable_path staging/mpv 2>/dev/null || true
-
-          # MoltenVK ICD so --gpu-api=vulkan works without a system Vulkan install;
-          # rewrite library_path to the bundled dylib. Homebrew installs the ICD
-          # under etc/ (not share/) and the path has drifted before, so locate it
-          # with find rather than hardcoding.
-          mkdir -p staging/share/vulkan/icd.d
-          icd_src=$(find -L "$(brew --prefix molten-vk)" -name MoltenVK_icd.json 2>/dev/null | head -1)
-          test -n "$icd_src" || { echo "!! MoltenVK_icd.json not found under molten-vk prefix" >&2; exit 1; }
-          sed 's#"library_path"[[:space:]]*:[[:space:]]*"[^"]*"#"library_path": "../../../libMoltenVK.dylib"#' \
-            "$icd_src" > staging/share/vulkan/icd.d/MoltenVK_icd.json
-
-          # Gate: nothing must still link an absolute brew/local path.
-          leak=$(for f in staging/mpv staging/*.dylib; do
-                   otool -L "$f" | awk 'NR>1 {print $1}'
-                 done | grep -E '^/(opt/homebrew|usr/local)' | sort -u || true)
-          if [ -n "$leak" ]; then
-            echo "!! un-bundled absolute references remain:" >&2
-            echo "$leak" >&2
-            exit 1
-          fi
-
-          cd staging
-          zip -r "../mpv-omniphony-${GITHUB_REF_NAME}-macos-arm64.zip" .
+          # Single artifact: the .app. CLI users run mpv-omniphony.app/Contents/MacOS/mpv
+          # (the binary needs Contents/Frameworks + Resources for MoltenVK/ICD).
+          zip -ry "${GITHUB_WORKSPACE}/mpv-omniphony-${GITHUB_REF_NAME}-macos-arm64.zip" mpv-omniphony.app
 
       - uses: actions/upload-artifact@v4
         with:
           name: mpv-omniphony-macos-arm64
           path: mpv-omniphony-*-macos-arm64.zip
-
-      - name: Build .app bundle
-        # Double-clickable app for users who don't want the bare CLI zip. Layout
-        # mirrors 9beach/mpv-app-bundle: binary in MacOS/, dylibs in Frameworks/,
-        # ICD in Resources/. Ad-hoc signed (no Apple Developer ID), so Gatekeeper
-        # quarantines it on download — README documents the `xattr` unblock step.
-        run: |
-          APP="mpv-omniphony.app"
-          mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Frameworks" \
-                   "$APP/Contents/Resources/vulkan/icd.d"
-          cp staging/mpv "$APP/Contents/MacOS/mpv"
-          cp staging/*.dylib "$APP/Contents/Frameworks/"
-          cp staging/orender.h README.md "$APP/Contents/Resources/" 2>/dev/null || true
-          cp staging/share/vulkan/icd.d/MoltenVK_icd.json \
-            "$APP/Contents/Resources/vulkan/icd.d/"
-          # Binary lives in MacOS/, dylibs in ../Frameworks: add that rpath.
-          install_name_tool -add_rpath @executable_path/../Frameworks \
-            "$APP/Contents/MacOS/mpv" 2>/dev/null || true
-          cat > "$APP/Contents/Info.plist" <<'PLIST'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-           "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0"><dict>
-            <key>CFBundleName</key><string>mpv-omniphony</string>
-            <key>CFBundleDisplayName</key><string>mpv-omniphony</string>
-            <key>CFBundleIdentifier</key><string>fr.mgth.mpv-omniphony</string>
-            <key>CFBundleExecutable</key><string>mpv</string>
-            <key>CFBundlePackageType</key><string>APPL</string>
-            <key>CFBundleShortVersionString</key><string>0.41.0</string>
-            <key>LSMinimumSystemVersion</key><string>11.0</string>
-            <key>NSHighResolutionCapable</key><true/>
-          </dict></plist>
-          PLIST
-          # Ad-hoc sign (nested dylibs too) so the bundle loads under Gatekeeper
-          # once the user clears the download quarantine.
-          codesign --force --deep --sign - "$APP"
-          codesign --verify --deep --strict "$APP" || true
-          zip -r "mpv-omniphony-${GITHUB_REF_NAME}-macos-arm64-app.zip" "$APP"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: mpv-omniphony-macos-arm64-app
-          path: mpv-omniphony-*-macos-arm64-app.zip
 
   release:
     needs: [build-linux, build-windows, build-macos]
@@ -691,10 +601,6 @@ jobs:
         with:
           name: mpv-omniphony-macos-arm64
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: mpv-omniphony-macos-arm64-app
-
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
@@ -709,13 +615,15 @@ jobs:
             Windows. The live overlay is built into mpv itself — no script to
             install.
 
-            **macOS (Apple Silicon):** two archives — `…-macos-arm64.zip` (the
-            CLI binary with all dylibs bundled, self-contained: no Homebrew
-            ffmpeg required) and `…-macos-arm64-app.zip` (a double-clickable
-            `mpv-omniphony.app`). Both are ad-hoc signed, not notarized, so the
-            first launch is blocked by Gatekeeper. Clear the download quarantine
-            once: `xattr -dr com.apple.quarantine /path/to/mpv-omniphony.app`
-            (or the extracted `mpv`), or right-click → Open the first time.
+            **macOS (Apple Silicon):** `…-macos-arm64.zip` contains a
+            self-contained, double-clickable `mpv-omniphony.app` (built with
+            mpv's own bundler — every dylib incl. ffmpeg and MoltenVK is bundled,
+            no Homebrew required). CLI users run
+            `mpv-omniphony.app/Contents/MacOS/mpv`. It is ad-hoc signed, not
+            notarized, so the first launch is blocked by Gatekeeper — clear the
+            download quarantine once with
+            `xattr -dr com.apple.quarantine /path/to/mpv-omniphony.app`, or
+            right-click → Open the first time.
 
             **Upgrading?** The overlay is now built in: delete any
             `omniphony-overlay.lua` you previously copied into your mpv
@@ -742,4 +650,3 @@ jobs:
             mpv-omniphony-*-linux-x86_64.zip
             mpv-omniphony-*-windows-x86_64.zip
             mpv-omniphony-*-macos-arm64.zip
-            mpv-omniphony-*-macos-arm64-app.zip


### PR DESCRIPTION
## Why

macOS users can't launch our build (#22): `libavcodec build version X incompatible with runtime version Y`, and our self-contained `.app` also fails. A user confirmed **m154k1/mpv-build-macOS works** — it bundles with mpv's own `meson compile macos-bundle`. We had **reimplemented** macOS bundling by hand (3 bugs this session), and our `.app`'s MoltenVK ICD `library_path` resolved *outside* the bundle → Vulkan init fails.

## What

Replace the hand-rolled `Package (zip)` walker **and** the manual `Build .app` step with mpv's upstream **`macos-bundle`** target (`TOOLS/osxbundle.py` + `dylib_unhell.py`):
- relocates every non-system dylib (liborender + brew ffmpeg/libass/libplacebo stack) into `Contents/MacOS/lib` → the app loads its **own** ffmpeg, killing the version mismatch;
- `process_vulkan_loader()` bundles `libMoltenVK` into `Contents/Frameworks` and writes a **correct** ICD into `Contents/Resources/vulkan/icd.d` (the exact thing our hand-rolled `.app` got wrong);
- forces `-Dcocoa=enabled -Dswift-build=enabled -Dvulkan=enabled` (build the GUI/Vulkan display stack; fail loud, not a no-video bundle);
- ships a **single** self-contained `mpv-omniphony.app` (rebranded Info.plist, re-signed). CLI users run `mpv-omniphony.app/Contents/MacOS/mpv`.

Keeps Homebrew deps (no full from-source needed — `dylib_unhell` knows the brew prefix). Linux/Windows jobs untouched.

## Verification

CI smoke test (headless runner): `--version`, vulkan gpu-api listed, MoltenVK + ICD bundled, no residual `/opt/homebrew|/usr/local` refs, codesign verify. **A real-Mac tester (Dkfc123, #22) must confirm launch + playback + `--gpu-api=vulkan`** — neither I nor the owner has a Mac.

Refs #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)