### PR TITLE
ci(fel,macos): fix osxbundle version.h IndexError

### DIFF
--- a/.github/workflows/build-fel.yml
+++ b/.github/workflows/build-fel.yml
@@ -297,6 +297,13 @@ jobs:
           PREFIX="$GITHUB_WORKSPACE/fel-prefix"
           export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:${{ github.workspace }}/sysroot/usr/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig"
           cd "$MPV_DIR"
+          # osxbundle.py's bundle_version() insists on `#define VERSION "v..."`,
+          # but this git-snapshot build of mpv master falls back to MPV_VERSION
+          # ("0.41.0-UNKNOWN", no leading v) → the bundler dies with IndexError.
+          # Prefix the generated version with `v` if it lacks one. (The v0.41.0
+          # tarball builds already carry the v, so this is FEL/master-only.)
+          vh=_b/common/version.h
+          [ -f "$vh" ] && sed -i '' -E 's/(#define[[:space:]]+VERSION[[:space:]]+")([^v"])/\1v\2/' "$vh"
           meson compile -C _b macos-bundle   # -> _b/mpv.app
 
       - name: Brand, verify and package the .app


### PR DESCRIPTION
After the re-vendor (#40) unblocked the FEL build, the macOS `macos-bundle` step crashed: mpv master's `osxbundle.py` requires `#define VERSION "v..."`, but the master git-snapshot build falls back to `MPV_VERSION` (`0.41.0-UNKNOWN`, no `v`) → `re.findall(...)[0]` → IndexError. Prefix the version with `v` if missing, just before `macos-bundle`. FEL/master-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)