### PR TITLE
ci(release): publish player bundles on the engine repo (download hub)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,11 +606,28 @@ jobs:
         with:
           name: mpv-omniphony-macos-arm64
 
-      - name: Create draft release
+      # Resolve the engine commit this build embeds, so the relocated release is
+      # tagged at the exact liborender source it was compiled against (GPL §6).
+      - name: Resolve engine commit for the release tag
+        id: engineref
+        env:
+          GH_TOKEN: ${{ secrets.OMNIPHONY_RELEASE_TOKEN }}
+        run: echo "sha=$(gh api repos/mgth/Omniphony/commits/${OMNIPHONY_REF} --jq .sha)" >> "$GITHUB_OUTPUT"
+
+      # Publish the player bundles on the ENGINE repo's Releases page (the canonical
+      # download hub) rather than here. Builds still run on mpv-omniphony; only the
+      # publish target moves. The `mpv-v*` tag namespace avoids the engine repo's own
+      # `v*` (Studio) and `liborender-v*` release triggers. Requires the
+      # OMNIPHONY_RELEASE_TOKEN secret (contents:write on mgth/Omniphony).
+      - name: Publish release on the engine repo (download hub)
         uses: softprops/action-gh-release@v2
         with:
+          repository: mgth/Omniphony
+          token: ${{ secrets.OMNIPHONY_RELEASE_TOKEN }}
+          tag_name: mpv-${{ github.ref_name }}
+          target_commitish: ${{ steps.engineref.outputs.sha }}
           draft: true
-          name: ${{ github.ref_name }}
+          name: mpv-omniphony ${{ github.ref_name }}
           body: |
             mpv-omniphony ${{ github.ref_name }} — mpv with the ad_orender
             spatial audio decoder.


### PR DESCRIPTION
Makes **[mgth/Omniphony](https://github.com/mgth/Omniphony)** the single download hub by relocating the standard player release to the engine repo's Releases page (Studio `v*` + liborender `liborender-v*` + player `mpv-v*`). Routes the *download/use* traffic to the engine without an org transfer. Builds still run here; only the publish step's target moves (softprops `repository:`/`token:`).

### Why draft / what you must do first
This needs a new repo secret **`OMNIPHONY_RELEASE_TOKEN`** — a fine-grained PAT (or GitHub App token) with **contents: write on `mgth/Omniphony`**. The default `GITHUB_TOKEN` cannot write cross-repo. **Do not merge until the secret exists**, or the next `v*` release will fail at the publish step.

```sh
# after creating the PAT:
gh secret set OMNIPHONY_RELEASE_TOKEN --repo mgth/mpv-omniphony --body '<token>'
```

### Safety checks
- `mpv-v*` matches neither the engine's `v*` (Studio) nor `liborender-v*` triggers → no accidental Studio build (verified against both workflows).
- Tagged at the resolved `OMNIPHONY_REF` commit the build embeds (GPL §6 corresponding source).
- FEL beta (`build-fel.yml`) and the rolling `integration` build are **not** relocated.

### Test before relying on it
Push a throwaway `v0.0.0-test`-style tag (or `workflow_dispatch`) and confirm the assets land as an `mpv-v0.0.0-test` draft release on `mgth/Omniphony`, that no Studio/liborender build triggered, then delete the test release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)