### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -24,7 +24,7 @@ jobs:
   build-mpv-master:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       MPV_TAG: v0.41.0     # keep in sync with scripts/ and PKGBUILD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build deps
         run: |

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -24,7 +24,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mpv build deps
         run: |
@@ -36,7 +36,7 @@ jobs:
             libbluray-dev libdvdnav-dev libdvdread-dev
 
       - name: Checkout Omniphony (renderer source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: mgth/Omniphony
           ref: ${{ env.OMNIPHONY_REF }}
@@ -92,7 +92,7 @@ jobs:
           zip -r "../mpv-omniphony-integration-linux-x86_64.zip" \
             mpv liborender.so.0 orender.h README.md
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: mpv-omniphony-linux-x86_64
           path: mpv-omniphony-integration-linux-x86_64.zip
@@ -101,7 +101,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Omniphony (renderer source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: mgth/Omniphony
           ref: ${{ env.OMNIPHONY_REF }}
@@ -122,7 +122,7 @@ jobs:
           Copy-Item omniphony-renderer/target/release/orender.dll out/
           Copy-Item omniphony-renderer/orender_ffi/include/orender.h out/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: liborender-windows-from-source
           path: out
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Bootstrap Arch + Martchus mingw-w64 repo
         run: |
@@ -217,7 +217,7 @@ jobs:
           x86_64-w64-mingw32-pkg-config --modversion lua52
 
       - name: Download liborender (built from source)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: liborender-windows-from-source
           path: /tmp/liborender
@@ -330,7 +330,7 @@ jobs:
           cd staging
           zip -r "../mpv-omniphony-integration-windows-x86_64.zip" .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: mpv-omniphony-windows-x86_64
           path: mpv-omniphony-integration-windows-x86_64.zip
@@ -342,7 +342,7 @@ jobs:
   build-macos:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mpv build deps (Homebrew)
         run: |
@@ -357,7 +357,7 @@ jobs:
             libbluray libdvdnav libdvdread
 
       - name: Checkout Omniphony (renderer source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: mgth/Omniphony
           ref: ${{ env.OMNIPHONY_REF }}
@@ -444,7 +444,7 @@ jobs:
           [ -z "$leak" ] || { echo "!! un-bundled absolute references remain:" >&2; echo "$leak" >&2; exit 1; }
           zip -ry "${GITHUB_WORKSPACE}/mpv-omniphony-integration-macos-arm64.zip" mpv-omniphony.app
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: mpv-omniphony-macos-arm64
           path: mpv-omniphony-integration-macos-arm64.zip
@@ -455,15 +455,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: mpv-omniphony-linux-x86_64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: mpv-omniphony-windows-x86_64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: mpv-omniphony-macos-arm64
 
@@ -474,7 +474,7 @@ jobs:
         run: gh release delete integration --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
 
       - name: Publish rolling integration pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: integration
           name: 'mpv-omniphony (integration build)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mpv build deps
         run: |
@@ -43,7 +43,7 @@ jobs:
             libbluray-dev libdvdnav-dev libdvdread-dev
 
       - name: Checkout Omniphony (renderer source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: mgth/Omniphony
           ref: ${{ env.OMNIPHONY_REF }}
@@ -125,7 +125,7 @@ jobs:
           zip -r "../mpv-omniphony-${GITHUB_REF_NAME}-linux-x86_64.zip" \
             mpv liborender.so.0 orender.h README.md
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: mpv-omniphony-linux-x86_64
           path: mpv-omniphony-*-linux-x86_64.zip
@@ -137,7 +137,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Omniphony (renderer source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: mgth/Omniphony
           ref: ${{ env.OMNIPHONY_REF }}
@@ -158,7 +158,7 @@ jobs:
           Copy-Item omniphony-renderer/target/release/orender.dll out/
           Copy-Item omniphony-renderer/orender_ffi/include/orender.h out/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: liborender-windows-from-source
           path: out
@@ -171,7 +171,7 @@ jobs:
     # apt's mingw-w64-* packages don't carry.
     container: archlinux:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Bootstrap Arch + Martchus mingw-w64 repo
         run: |
@@ -298,7 +298,7 @@ jobs:
           x86_64-w64-mingw32-pkg-config --modversion ffnvcodec
 
       - name: Download liborender (built from source)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: liborender-windows-from-source
           path: /tmp/liborender
@@ -446,7 +446,7 @@ jobs:
           cd staging
           zip -r "../mpv-omniphony-${GITHUB_REF_NAME}-windows-x86_64.zip" .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: mpv-omniphony-windows-x86_64
           path: mpv-omniphony-*-windows-x86_64.zip
@@ -456,7 +456,7 @@ jobs:
   build-macos:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mpv build deps (Homebrew)
         run: |
@@ -471,7 +471,7 @@ jobs:
             libbluray libdvdnav libdvdread
 
       - name: Checkout Omniphony (renderer source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: mgth/Omniphony
           ref: ${{ env.OMNIPHONY_REF }}
@@ -583,7 +583,7 @@ jobs:
           # (the binary needs Contents/Frameworks + Resources for MoltenVK/ICD).
           zip -ry "${GITHUB_WORKSPACE}/mpv-omniphony-${GITHUB_REF_NAME}-macos-arm64.zip" mpv-omniphony.app
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: mpv-omniphony-macos-arm64
           path: mpv-omniphony-*-macos-arm64.zip
@@ -594,15 +594,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: mpv-omniphony-linux-x86_64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: mpv-omniphony-windows-x86_64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: mpv-omniphony-macos-arm64
 
@@ -620,7 +620,7 @@ jobs:
       # `v*` (Studio) and `liborender-v*` release triggers. Requires the
       # OMNIPHONY_RELEASE_TOKEN secret (contents:write on mgth/Omniphony).
       - name: Publish release on the engine repo (download hub)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           repository: mgth/Omniphony
           token: ${{ secrets.OMNIPHONY_RELEASE_TOKEN }}


### PR DESCRIPTION
GitHub is deprecating the Node 20 runtime ([2025-09-19 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)); runners now force-upgrade Node20 actions to Node24 and warn on every run.

Pins each affected first-party action to its **first major that natively targets Node 24** (minimal jump = least behavioral change):

| Action | Before | After | Note |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | |
| `actions/upload-artifact` | v4 | **v6** | v5 is still node20 |
| `actions/download-artifact` | v4 | **v7** | v5/v6 still node20 |
| `softprops/action-gh-release` | v2 | **v3** | |

`upload-artifact` / `download-artifact` stay on the shared v4+ artifact backend, so the mixed majors remain cross-compatible. `dtolnay/rust-toolchain` is a composite action (no Node runtime) and is unaffected.

Scope: the four workflows on `main` (`release.yml`, `integration-build.yml`, `build-master.yml`, `ci.yml`). The FEL prerelease workflow (`build-fel.yml` → `build-master-beta.yml`, which additionally uses `actions/cache@v4 -> v5`) carries the same bump on its own branch, so it is not part of this PR.

Pure version bumps, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)