### PR TITLE
patches: refresh decoder integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,14 @@ Develop the integration in a fork of `mpv-player/mpv`:
 git remote add upstream https://github.com/mpv-player/mpv.git
 git fetch upstream
 git checkout master && git merge upstream/master
-git checkout orender && git rebase master       # resolve drift
-scripts/regenerate-patches.sh /path/to/mpv-fork # refresh patches/ here
+git checkout orender
+# Integrate the decoder changes here, but keep this branch based on v0.41.0.
+scripts/regenerate-patches.sh /path/to/mpv-fork v0.41.0
 ```
+
+Do not rebase `orender` onto `master`: the stable patch series is intentionally
+generated from the pinned `v0.41.0` base. Only `orender-master`, described
+below, follows current upstream `master`.
 
 ## Tracking mpv master
 

--- a/patches-master/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches-master/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/21] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/24] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches-master/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/21] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/24] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches-master/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches-master/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/21] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/24] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches-master/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches-master/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/21] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/24] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches-master/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches-master/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/21] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/24] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches-master/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/21] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/24] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches-master/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/21] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/24] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches-master/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/21] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/24] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches-master/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches-master/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/21] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/24] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches-master/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/21] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/24] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches-master/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches-master/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 13 Jun 2026 11:10:05 +0200
-Subject: [PATCH 11/21] ad_orender: ProgramData config path in the Windows
+Subject: [PATCH 11/24] ad_orender: ProgramData config path in the Windows
  bridge_path hint
 
 The renderer's Windows default config moved to %ProgramData%\omniphony\

--- a/patches-master/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
+++ b/patches-master/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 14:28:27 +0200
-Subject: [PATCH 12/21] ad_orender: host channel-mode fallback to the native
+Subject: [PATCH 12/24] ad_orender: host channel-mode fallback to the native
  decoder
 
 Add --ad-orender-channel-mode (auto/host/direct/virtual) and, in host mode on a

--- a/patches-master/0013-ad_orender-route-DTS-to-orender-too.patch
+++ b/patches-master/0013-ad_orender-route-DTS-to-orender-too.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 16:37:06 +0200
-Subject: [PATCH 13/21] ad_orender: route DTS to orender too
+Subject: [PATCH 13/24] ad_orender: route DTS to orender too
 
 Add "dts" to the codec gate in f_decoder_wrapper (decoder selection) and
 ad_orender (create + add_decoders + codec_desc), so DTS tracks decode through

--- a/patches-master/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
+++ b/patches-master/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 15 Jun 2026 08:14:44 +0200
-Subject: [PATCH 14/21] ad_orender: render AC-3 through orender; fix
+Subject: [PATCH 14/24] ad_orender: render AC-3 through orender; fix
  channel-mode option
 
 - Offer the orender decoder for the `ac3` codec (in addition to truehd,

--- a/patches-master/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
+++ b/patches-master/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:25:41 +0200
-Subject: [PATCH 15/21] feat(ad_orender): keep the engine alive in host mode;
+Subject: [PATCH 15/24] feat(ad_orender): keep the engine alive in host mode;
  live spatial<->host
 
 ad_orender is now the persistent decoder for the supported codecs and

--- a/patches-master/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
+++ b/patches-master/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:35:47 +0200
-Subject: [PATCH 16/21] feat(ad_orender): hide the spatial overlay in host mode
+Subject: [PATCH 16/24] feat(ad_orender): hide the spatial overlay in host mode
 
 When routing channel audio to the native host decoder, suppress the whole
 spatial overlay (wireframe cube included) via orender_overlay_set_rendering(0)

--- a/patches-master/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
+++ b/patches-master/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 23:47:09 +0200
-Subject: [PATCH 17/21] feat(ad_orender): show Atmos profile, bed+objects and
+Subject: [PATCH 17/24] feat(ad_orender): show Atmos profile, bed+objects and
  DialNorm in track info
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
+++ b/patches-master/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 08:25:51 +0200
-Subject: [PATCH 18/21] fix(ad_orender): label track profile from decoded
+Subject: [PATCH 18/24] fix(ad_orender): label track profile from decoded
  objects, not is_spatial
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
+++ b/patches-master/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 18:51:09 +0200
-Subject: [PATCH 19/21] feat(ad_orender): honor renderer output channel mapping
+Subject: [PATCH 19/24] feat(ad_orender): honor renderer output channel mapping
  (by-index/by-name), live
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
+++ b/patches-master/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 20 Jun 2026 21:55:59 +0200
-Subject: [PATCH 20/21] fix(ad_orender): anchor codec_profile buffer to codec
+Subject: [PATCH 20/24] fix(ad_orender): anchor codec_profile buffer to codec
  lifetime
 
 codec_profile was published from p->profile_buf, which lived inline in

--- a/patches-master/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
+++ b/patches-master/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 2 Jul 2026 17:35:46 +0200
-Subject: [PATCH 21/21] ad_orender: load liborender at runtime with an ABI
+Subject: [PATCH 21/24] ad_orender: load liborender at runtime with an ABI
  handshake
 
 mpv linked liborender at build time (DT_NEEDED liborender.so.0), which

--- a/patches-master/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
+++ b/patches-master/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
@@ -1,0 +1,239 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Mon, 20 Jul 2026 18:23:18 +0200
+Subject: [PATCH 22/24] fix(ad): keep object content on spatial renderer
+
+---
+ audio/decode/ad_orender.c | 116 ++++++++++++++++++++++++++++++++++----
+ 1 file changed, 105 insertions(+), 11 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 245afae3b6..15b94c6f49 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -9,7 +9,8 @@
+  * decoder wrapper in host mode. It stays selected for the whole track and owns
+  * the orender engine the whole time, so the engine's OSC listener — and thus the
+  * Studio connection — stays alive and keeps receiving the live
+- * `channel_render_mode` switch. Each packet is routed on that live mode:
++ * `channel_render_mode` switch. Object content stays on the spatial path;
++ * channel-based content is routed on the live mode:
+  *
+  *   - spatial : decode + VBAP-render through the engine (objects, or the virtual
+  *               bed for plain channel content);
+@@ -28,6 +29,8 @@
+ #include <stdint.h>
+ #include <string.h>
+ 
++#include <libavcodec/avcodec.h>
++
+ #include "mpv_talloc.h"
+ #include "audio/aframe.h"
+ #include "audio/chmap.h"
+@@ -101,10 +104,15 @@ struct priv {
+     struct mp_chmap chmap;
+     bool checked_spatial;       // built the output chmap for the spatial path
+     int last_mapping;           // last orender_channel_mapping() the chmap was built for (live switch)
++    bool source_spatial;        // container/bridge identified object content
++    bool source_classified;     // first decoded presentation has been inspected
+     bool force_host;            // engine unusable (no layout / create failed): always native
+     int host_decoder_idx;       // HOST_DEC_LAVC (PCM) or HOST_DEC_SPDIF (passthrough)
+     struct mp_decoder *native;  // lazily-created native child decoder for host mode
+     int active_path;            // PATH_* of the last packet, for clean transitions
++    struct mp_frame *probe_packets; // packets retained while classifying the source
++    int num_probe_packets;
++    int probe_packet_pos;
+     /* Track-info codec profile (shift+I) for the spatial path. Two concerns:
+      *
+      *  - Lifetime: the core thread reads codec_profile from the track list
+@@ -218,6 +226,28 @@ static const char *profile_base(const char *codec, bool has_objects)
+     return codec;
+ }
+ 
++/* FFmpeg can expose DTS:X directly in AVCodecParameters.profile, letting the
++ * demuxer identify it before either decoder consumes a packet. Use that early
++ * hint when available; otherwise the retained-packet probe below lets the
++ * bridge classify the presentation without losing the native fallback audio. */
++static bool codec_is_spatial_hint(const struct mp_codec_params *codec)
++{
++    const char *profile = codec->codec_profile;
++    if (profile && (strstr(profile, "DTS:X") || strstr(profile, "Atmos")))
++        return true;
++
++    int av_profile = codec->lav_codecpar ? codec->lav_codecpar->profile
++                                         : AV_PROFILE_UNKNOWN;
++    if (strcmp(codec->codec, "dts") == 0)
++        return av_profile == AV_PROFILE_DTS_HD_MA_X ||
++               av_profile == AV_PROFILE_DTS_HD_MA_X_IMAX;
++    if (strcmp(codec->codec, "eac3") == 0)
++        return av_profile == AV_PROFILE_EAC3_DDP_ATMOS;
++    if (strcmp(codec->codec, "truehd") == 0)
++        return av_profile == AV_PROFILE_TRUEHD_ATMOS;
++    return false;
++}
++
+ /* Recompose codec_profile from the engine's live presentation info (Atmos flag,
+  * bed composition, object count, DialNorm) and publish it for the track-info
+  * display. Cheap and idempotent: returns immediately unless the value changed. */
+@@ -356,6 +386,14 @@ static bool ensure_native_child(struct mp_filter *da, struct priv *p)
+     return true;
+ }
+ 
++static void clear_probe_packets(struct priv *p)
++{
++    for (int i = p->probe_packet_pos; i < p->num_probe_packets; i++)
++        mp_frame_unref(&p->probe_packets[i]);
++    p->num_probe_packets = 0;
++    p->probe_packet_pos = 0;
++}
++
+ /* Host mode: pump the native child — forward packets in, decoded frames out. */
+ static void process_host(struct mp_filter *da, struct priv *p)
+ {
+@@ -373,21 +411,40 @@ static void process_host(struct mp_filter *da, struct priv *p)
+         mp_pin_in_write(da->ppins[1], frame);
+     }
+     // Feed input packets to the child.
+-    if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
++    if (p->probe_packet_pos < p->num_probe_packets &&
++        mp_pin_in_needs_data(child_in))
++    {
++        struct mp_frame frame = p->probe_packets[p->probe_packet_pos];
++        p->probe_packets[p->probe_packet_pos++] = MP_NO_FRAME;
++        mp_pin_in_write(child_in, frame);
++        if (p->probe_packet_pos == p->num_probe_packets) {
++            p->num_probe_packets = 0;
++            p->probe_packet_pos = 0;
++        }
++    } else if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
+         struct mp_frame frame = mp_pin_out_read(da->ppins[0]);
+         mp_pin_in_write(child_in, frame);
+     }
+ }
+ 
+ /* Spatial mode: decode + VBAP-render through the engine. */
+-static void process_spatial(struct mp_filter *da, struct priv *p)
++static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_host)
+ {
+     if (!mp_pin_can_transfer_data(da->ppins[1], da->ppins[0]))
+         return;
+ 
+     struct mp_frame inframe = mp_pin_out_read(da->ppins[0]);
+     if (inframe.type == MP_FRAME_EOF) {
+-        mp_pin_in_write(da->ppins[1], inframe);
++        if (probe_host && p->num_probe_packets > 0) {
++            MP_TARRAY_APPEND(p, p->probe_packets, p->num_probe_packets, inframe);
++            p->source_classified = true;
++            p->active_path = PATH_HOST;
++            p->dl->overlay_set_rendering(0);
++            p->dl->overlay_clear();
++            process_host(da, p);
++        } else {
++            mp_pin_in_write(da->ppins[1], inframe);
++        }
+         return;
+     } else if (inframe.type != MP_FRAME_PACKET) {
+         if (inframe.type) {
+@@ -430,6 +487,34 @@ static void process_spatial(struct mp_filter *da, struct priv *p)
+         goto done;
+     }
+ 
++    if (probe_host) {
++        /* Keep ownership of every packet until the bridge can classify the
++         * first decoded presentation. If it is a plain channel stream, replay
++         * these packets into the native decoder so probing loses no audio. */
++        MP_TARRAY_APPEND(p, p->probe_packets, p->num_probe_packets, inframe);
++        inframe = MP_NO_FRAME;
++        mpkt = NULL;
++    }
++
++    int spatial = p->dl->is_spatial(p->renderer);
++    if (spatial == 1) {
++        p->source_spatial = true;
++        p->source_classified = true;
++        clear_probe_packets(p);
++        p->dl->overlay_set_rendering(1);
++    } else if (probe_host && n_frames > 0) {
++        /* The bridge produced a real non-object frame: classification is now
++         * definitive. Discard the probe render and replay from packet zero via
++         * the native child selected for channel-based sources. */
++        p->source_classified = true;
++        p->active_path = PATH_HOST;
++        p->dl->overlay_set_rendering(0);
++        p->dl->overlay_clear();
++        talloc_free(samples);
++        process_host(da, p);
++        return;
++    }
++
+     if (n_frames == 0)
+         goto done;   /* packet consumed; no output yet (need more data) */
+ 
+@@ -546,11 +631,12 @@ static void ad_orender_process(struct mp_filter *da)
+ {
+     struct priv *p = da->priv;
+ 
+-    /* Route on the engine's live channel_render_mode (0 host, 1 spatial), which
+-     * Studio flips over OSC. Reading it per packet is a cheap in-memory call, not
+-     * a poll. `force_host` (engine unusable) pins host. */
++    /* The live channel mode only selects what to do with channel-based sources.
++     * Object content identified by the container or bridge always stays on the
++     * spatial path, independently of Studio's "Spatialize 2D sources" toggle. */
+     int mode = p->renderer ? p->dl->channel_mode(p->renderer) : 0;
+-    bool host = p->force_host || mode != 1;
++    bool probe_host = !p->force_host && !p->source_classified && mode != 1;
++    bool host = p->force_host || (!probe_host && !p->source_spatial && mode != 1);
+     int path = host ? PATH_HOST : PATH_SPATIAL;
+ 
+     /* On a mode flip, flush stale state on the side we switch *to* so it starts
+@@ -584,7 +670,7 @@ static void ad_orender_process(struct mp_filter *da)
+     if (host)
+         process_host(da, p);
+     else
+-        process_spatial(da, p);
++        process_spatial(da, p, probe_host);
+ }
+ 
+ static void ad_orender_reset(struct mp_filter *da)
+@@ -594,6 +680,7 @@ static void ad_orender_reset(struct mp_filter *da)
+         p->dl->reset(p->renderer);
+     if (p->native && p->native->f)
+         mp_filter_reset(p->native->f);
++    clear_probe_packets(p);
+     p->checked_spatial = false;
+     p->active_path = PATH_NONE;
+ }
+@@ -601,6 +688,7 @@ static void ad_orender_reset(struct mp_filter *da)
+ static void ad_orender_destroy(struct mp_filter *da)
+ {
+     struct priv *p = da->priv;
++    clear_probe_packets(p);
+     /* The native child is a talloc child of `da` and is freed with it; the
+      * engine is an FFI handle we must release explicitly. The codec profile
+      * buffer is a talloc child of p->codec (not of `da`), so it correctly
+@@ -642,8 +730,14 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->codec = codec;
+     p->sample_rate = codec->samplerate;
+     p->active_path = PATH_NONE;
++    p->source_spatial = codec_is_spatial_hint(codec);
++    p->source_classified = p->source_spatial;
+     p->public.f = da;
+ 
++    MP_VERBOSE(da, "input profile: %s (early spatial=%s)\n",
++               codec->codec_profile ? codec->codec_profile : "unknown",
++               p->source_spatial ? "yes" : "no");
++
+     struct ad_orender_params *opts =
+         mp_get_config_group(da, da->global, &ad_orender_conf);
+     p->host_decoder_idx = opts->host_decoder_idx;
+@@ -711,8 +805,8 @@ static struct mp_decoder *create(struct mp_filter *parent,
+ 
+     /* Match the overlay's initial visibility to the starting mode, so it does not
+      * flash the wireframe cube before the first packet picks the path. */
+-    bool start_host = p->force_host ||
+-                      !p->renderer || p->dl->channel_mode(p->renderer) != 1;
++    bool start_host = p->force_host || !p->renderer ||
++                      (!p->source_spatial && p->dl->channel_mode(p->renderer) != 1);
+     p->dl->overlay_set_rendering(start_host ? 0 : 1);
+ 
+     /* Official-cased codec name. No "(orender)" suffix: the decoder already shows

--- a/patches-master/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
+++ b/patches-master/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
@@ -1,0 +1,115 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 21 Jul 2026 15:43:51 +0200
+Subject: [PATCH 23/24] ad_orender: prefer orender_has_objects (ABI minor 6)
+
+Resolve the object-content probe from the new live-fact symbol
+orender_has_objects, falling back to its deprecated alias
+orender_is_spatial on pre-minor-6 engines (alias resolved first so the
+preferred name overwrites it when both exist). The dl-table field is
+renamed accordingly; vendored orender_abi.h synced (minor 6, updated
+semantics: the value is live, may flip mid-stream, and must not be
+latched beyond the initial host-probe classification).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c |  2 +-
+ common/orender_abi.h      | 14 ++++++++++----
+ common/orender_dl.c       |  8 +++++---
+ common/orender_dl.h       |  5 ++++-
+ 4 files changed, 20 insertions(+), 9 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 15b94c6f49..06c03f0fef 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -496,7 +496,7 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+         mpkt = NULL;
+     }
+ 
+-    int spatial = p->dl->is_spatial(p->renderer);
++    int spatial = p->dl->has_objects(p->renderer);
+     if (spatial == 1) {
+         p->source_spatial = true;
+         p->source_classified = true;
+diff --git a/common/orender_abi.h b/common/orender_abi.h
+index 0cf0c64d8f..a29e268dab 100644
+--- a/common/orender_abi.h
++++ b/common/orender_abi.h
+@@ -35,7 +35,7 @@
+ // C-ABI minor version: backwards-compatible additions only. Consumers should
+ // gate optional features on symbol presence (dlsym), not on this value; it
+ // exists for logging and diagnostics.
+-#define ORENDER_ABI_MINOR 5
++#define ORENDER_ABI_MINOR 6
+ 
+ // Speaker-position labels written by [`orender_channel_layout`] and
+ // [`orender_bed_layout`] (one byte per channel). Mirrors the engine's
+@@ -122,9 +122,15 @@ struct OrenderRenderer *orender_create(const struct OrenderConfig *cfg);
+ // Free a session created by [`orender_create`]. NULL is ignored.
+ void orender_destroy(struct OrenderRenderer *r);
+ 
+-// 1 if the current presentation carries spatial objects, 0 if it is a plain
+-// multichannel stream (the host should fall back to its standard decoder),
+-// <0 on error. Meaningful after at least one [`orender_process`] call.
++// 1 while the current presentation carries dynamic objects, 0 while it is a
++// plain multichannel stream, <0 on error. A live fact: it may flip in either
++// direction mid-stream and must not be latched; before the first decoded
++// frame it reports the bridge's container-level guess. Added in ABI minor 6 —
++// gate on dlsym presence.
++int orender_has_objects(const struct OrenderRenderer *r);
++
++// Deprecated alias of orender_has_objects (pre-minor-6 engines). Same values,
++// same live semantics.
+ int orender_is_spatial(const struct OrenderRenderer *r);
+ 
+ // Dynamic object count of the last rendered frame (decoded channels minus the
+diff --git a/common/orender_dl.c b/common/orender_dl.c
+index c1a182f7ee..1eae97b129 100644
+--- a/common/orender_dl.c
++++ b/common/orender_dl.c
+@@ -77,7 +77,7 @@ static void lib_close(void *handle)
+ 
+ /* ── no-op stubs for optional symbols ─────────────────────────────────────── */
+ 
+-static int stub_is_spatial(const struct OrenderRenderer *r) { return -1; }
++static int stub_has_objects(const struct OrenderRenderer *r) { return -1; }
+ static int stub_set_option(struct OrenderRenderer *r, const char *key,
+                            const char *value) { return -1; }
+ static const char *stub_build_id(void) { return NULL; }
+@@ -132,7 +132,7 @@ static const struct orender_dl stubs = {
+     .object_count = stub_object_count,
+     .dialnorm_db = stub_dialnorm_db,
+     .bed_layout = stub_layout,
+-    .is_spatial = stub_is_spatial,
++    .has_objects = stub_has_objects,
+     .set_option = stub_set_option,
+     .build_id = stub_build_id,
+     .overlay_set_rendering = stub_overlay_set_rendering,
+@@ -291,7 +291,9 @@ static bool try_load(struct mp_log *log, const char *path, const char *origin)
+      * older engine simply lacks the newer features — never a reason to reject. */
+     const struct { const char *name; size_t offset; } optional[] = {
+ #define OPT_SYM(field, sym) {sym, offsetof(struct orender_dl, field)}
+-        OPT_SYM(is_spatial,            "orender_is_spatial"),
++        /* Alias first so the preferred name overwrites it when both exist. */
++        OPT_SYM(has_objects,           "orender_is_spatial"),
++        OPT_SYM(has_objects,           "orender_has_objects"),
+         OPT_SYM(set_option,            "orender_set_option"),
+         OPT_SYM(build_id,              "orender_build_id"),
+         OPT_SYM(overlay_set_rendering, "orender_overlay_set_rendering"),
+diff --git a/common/orender_dl.h b/common/orender_dl.h
+index 6a69de6a57..385aef3bec 100644
+--- a/common/orender_dl.h
++++ b/common/orender_dl.h
+@@ -56,7 +56,10 @@ struct orender_dl {
+                            uint8_t *out_labels, uint32_t cap);
+ 
+     /* optional — stubbed when missing */
+-    int (*is_spatial)(const struct OrenderRenderer *r);
++    /* Resolved from orender_has_objects (ABI minor >= 6), falling back to
++     * its deprecated alias orender_is_spatial on older engines. Live fact:
++     * may flip mid-stream, never latch it. */
++    int (*has_objects)(const struct OrenderRenderer *r);
+     int (*set_option)(struct OrenderRenderer *r, const char *key,
+                       const char *value);
+     const char *(*build_id)(void);

--- a/patches-master/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
+++ b/patches-master/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
@@ -1,0 +1,92 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 21 Jul 2026 18:28:24 +0200
+Subject: [PATCH 24/24] =?UTF-8?q?fix(ad=5Forender):=20DTS:X=20silence=20in?=
+ =?UTF-8?q?=20host=20mode=20=E2=80=94=20classify=20from=20decoded=20frames?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A container-hinted DTS:X track (AV_PROFILE_DTS_HD_MA_X) was latched
+"spatial" at open time, so the probe never ran; the bridge correctly
+reports has_objects=false (a fixed 7.1.4 presentation is channel-based,
+not object content), so in host channel-mode the embedded engine
+returned HostPassthrough — silence — forever, and the native fallback
+never engaged. The only way to get audio was Studio's "Spatialize 2D
+sources" (spatial channel-mode), which routes through the virtual bed.
+
+Root cause: the classification trusted the provisional container hint
+instead of the decoded fact. Three coordinated changes make routing
+follow has_objects, which is a live fact per the channel-object
+contract:
+
+- open time: source_classified starts false (was = the hint), so a
+  hinted track still probes and can fall back to the native decoder;
+- the has_objects==1 branch is gated on n_frames > 0, so a real object
+  stream is only classified spatial from a decoded frame, never from
+  the pre-frame container guess;
+- the host-classify branch clears source_spatial: the decoded fact
+  overrides the hint. Without this, the next packet re-evaluated the
+  routing (host = not source_spatial and ...) with the stale hint still
+  true and bounced back to the spatial path (HostPassthrough silence) —
+  the actual mechanism of the bug.
+
+Verified via PCM capture (Ex Machina DTS:X): host mode now -30.7 dB,
+matching the pure native baseline exactly (was -91 dB silence); spatial
+mode -31.0 dB. No regression: plain DTS 5.1 host -32.5 dB, E-AC3 JOC
+Atmos still classifies spatial and renders in host channel-mode.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 06c03f0fef..9e8b739da1 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -496,16 +496,25 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+         mpkt = NULL;
+     }
+ 
++    /* Classify only from *decoded* frames: before the first frame,
++     * has_objects reports the bridge's container-level guess (e.g. TrueHD
++     * assumes objects until proven otherwise), and latching that guess is
++     * exactly the failure the live-fact contract forbids. */
+     int spatial = p->dl->has_objects(p->renderer);
+-    if (spatial == 1) {
++    if (spatial == 1 && n_frames > 0) {
+         p->source_spatial = true;
+         p->source_classified = true;
+         clear_probe_packets(p);
+         p->dl->overlay_set_rendering(1);
+     } else if (probe_host && n_frames > 0) {
+         /* The bridge produced a real non-object frame: classification is now
+-         * definitive. Discard the probe render and replay from packet zero via
+-         * the native child selected for channel-based sources. */
++         * definitive. The decoded fact overrides the provisional container
++         * hint — this presentation is channel-based, not object content — so
++         * clear source_spatial too, else the next packet's routing
++         * (host = !source_spatial && …) would bounce it back to the spatial
++         * path and render HostPassthrough silence. Discard the probe render
++         * and replay from packet zero via the native child. */
++        p->source_spatial = false;
+         p->source_classified = true;
+         p->active_path = PATH_HOST;
+         p->dl->overlay_set_rendering(0);
+@@ -731,7 +740,14 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->sample_rate = codec->samplerate;
+     p->active_path = PATH_NONE;
+     p->source_spatial = codec_is_spatial_hint(codec);
+-    p->source_classified = p->source_spatial;
++    /* The hint is provisional: routing follows the *decoded* fact (the
++     * engine's has_objects is live), so classification only happens once the
++     * bridge has produced frames. A container-profiled DTS:X track whose
++     * presentation is fixed channels (no dynamic objects) must still probe
++     * and fall back to the native path in host mode — terminally trusting
++     * the hint here left the embedded engine passing through silence
++     * forever (channel-object contract, phase 5). */
++    p->source_classified = false;
+     p->public.f = da;
+ 
+     MP_VERBOSE(da, "input profile: %s (early spatial=%s)\n",

--- a/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/21] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/24] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/21] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/24] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/21] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/24] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/21] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/24] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/21] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/24] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/21] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/24] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/21] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/24] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/21] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/24] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/21] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/24] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/21] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/24] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 13 Jun 2026 11:10:05 +0200
-Subject: [PATCH 11/21] ad_orender: ProgramData config path in the Windows
+Subject: [PATCH 11/24] ad_orender: ProgramData config path in the Windows
  bridge_path hint
 
 The renderer's Windows default config moved to %ProgramData%\omniphony\

--- a/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
+++ b/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 14:28:27 +0200
-Subject: [PATCH 12/21] ad_orender: host channel-mode fallback to the native
+Subject: [PATCH 12/24] ad_orender: host channel-mode fallback to the native
  decoder
 
 Add --ad-orender-channel-mode (auto/host/direct/virtual) and, in host mode on a

--- a/patches/0013-ad_orender-route-DTS-to-orender-too.patch
+++ b/patches/0013-ad_orender-route-DTS-to-orender-too.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 16:37:06 +0200
-Subject: [PATCH 13/21] ad_orender: route DTS to orender too
+Subject: [PATCH 13/24] ad_orender: route DTS to orender too
 
 Add "dts" to the codec gate in f_decoder_wrapper (decoder selection) and
 ad_orender (create + add_decoders + codec_desc), so DTS tracks decode through

--- a/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
+++ b/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 15 Jun 2026 08:14:44 +0200
-Subject: [PATCH 14/21] ad_orender: render AC-3 through orender; fix
+Subject: [PATCH 14/24] ad_orender: render AC-3 through orender; fix
  channel-mode option
 
 - Offer the orender decoder for the `ac3` codec (in addition to truehd,

--- a/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
+++ b/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:25:41 +0200
-Subject: [PATCH 15/21] feat(ad_orender): keep the engine alive in host mode;
+Subject: [PATCH 15/24] feat(ad_orender): keep the engine alive in host mode;
  live spatial<->host
 
 ad_orender is now the persistent decoder for the supported codecs and

--- a/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
+++ b/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:35:47 +0200
-Subject: [PATCH 16/21] feat(ad_orender): hide the spatial overlay in host mode
+Subject: [PATCH 16/24] feat(ad_orender): hide the spatial overlay in host mode
 
 When routing channel audio to the native host decoder, suppress the whole
 spatial overlay (wireframe cube included) via orender_overlay_set_rendering(0)

--- a/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
+++ b/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 23:47:09 +0200
-Subject: [PATCH 17/21] feat(ad_orender): show Atmos profile, bed+objects and
+Subject: [PATCH 17/24] feat(ad_orender): show Atmos profile, bed+objects and
  DialNorm in track info
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
+++ b/patches/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 08:25:51 +0200
-Subject: [PATCH 18/21] fix(ad_orender): label track profile from decoded
+Subject: [PATCH 18/24] fix(ad_orender): label track profile from decoded
  objects, not is_spatial
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
+++ b/patches/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 18:51:09 +0200
-Subject: [PATCH 19/21] feat(ad_orender): honor renderer output channel mapping
+Subject: [PATCH 19/24] feat(ad_orender): honor renderer output channel mapping
  (by-index/by-name), live
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
+++ b/patches/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 20 Jun 2026 21:55:59 +0200
-Subject: [PATCH 20/21] fix(ad_orender): anchor codec_profile buffer to codec
+Subject: [PATCH 20/24] fix(ad_orender): anchor codec_profile buffer to codec
  lifetime
 
 codec_profile was published from p->profile_buf, which lived inline in

--- a/patches/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
+++ b/patches/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 2 Jul 2026 17:35:46 +0200
-Subject: [PATCH 21/21] ad_orender: load liborender at runtime with an ABI
+Subject: [PATCH 21/24] ad_orender: load liborender at runtime with an ABI
  handshake
 
 mpv linked liborender at build time (DT_NEEDED liborender.so.0), which

--- a/patches/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
+++ b/patches/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
@@ -1,0 +1,239 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Mon, 20 Jul 2026 18:23:18 +0200
+Subject: [PATCH 22/24] fix(ad): keep object content on spatial renderer
+
+---
+ audio/decode/ad_orender.c | 116 ++++++++++++++++++++++++++++++++++----
+ 1 file changed, 105 insertions(+), 11 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 245afae3b6..15b94c6f49 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -9,7 +9,8 @@
+  * decoder wrapper in host mode. It stays selected for the whole track and owns
+  * the orender engine the whole time, so the engine's OSC listener — and thus the
+  * Studio connection — stays alive and keeps receiving the live
+- * `channel_render_mode` switch. Each packet is routed on that live mode:
++ * `channel_render_mode` switch. Object content stays on the spatial path;
++ * channel-based content is routed on the live mode:
+  *
+  *   - spatial : decode + VBAP-render through the engine (objects, or the virtual
+  *               bed for plain channel content);
+@@ -28,6 +29,8 @@
+ #include <stdint.h>
+ #include <string.h>
+ 
++#include <libavcodec/avcodec.h>
++
+ #include "mpv_talloc.h"
+ #include "audio/aframe.h"
+ #include "audio/chmap.h"
+@@ -101,10 +104,15 @@ struct priv {
+     struct mp_chmap chmap;
+     bool checked_spatial;       // built the output chmap for the spatial path
+     int last_mapping;           // last orender_channel_mapping() the chmap was built for (live switch)
++    bool source_spatial;        // container/bridge identified object content
++    bool source_classified;     // first decoded presentation has been inspected
+     bool force_host;            // engine unusable (no layout / create failed): always native
+     int host_decoder_idx;       // HOST_DEC_LAVC (PCM) or HOST_DEC_SPDIF (passthrough)
+     struct mp_decoder *native;  // lazily-created native child decoder for host mode
+     int active_path;            // PATH_* of the last packet, for clean transitions
++    struct mp_frame *probe_packets; // packets retained while classifying the source
++    int num_probe_packets;
++    int probe_packet_pos;
+     /* Track-info codec profile (shift+I) for the spatial path. Two concerns:
+      *
+      *  - Lifetime: the core thread reads codec_profile from the track list
+@@ -218,6 +226,28 @@ static const char *profile_base(const char *codec, bool has_objects)
+     return codec;
+ }
+ 
++/* FFmpeg can expose DTS:X directly in AVCodecParameters.profile, letting the
++ * demuxer identify it before either decoder consumes a packet. Use that early
++ * hint when available; otherwise the retained-packet probe below lets the
++ * bridge classify the presentation without losing the native fallback audio. */
++static bool codec_is_spatial_hint(const struct mp_codec_params *codec)
++{
++    const char *profile = codec->codec_profile;
++    if (profile && (strstr(profile, "DTS:X") || strstr(profile, "Atmos")))
++        return true;
++
++    int av_profile = codec->lav_codecpar ? codec->lav_codecpar->profile
++                                         : AV_PROFILE_UNKNOWN;
++    if (strcmp(codec->codec, "dts") == 0)
++        return av_profile == AV_PROFILE_DTS_HD_MA_X ||
++               av_profile == AV_PROFILE_DTS_HD_MA_X_IMAX;
++    if (strcmp(codec->codec, "eac3") == 0)
++        return av_profile == AV_PROFILE_EAC3_DDP_ATMOS;
++    if (strcmp(codec->codec, "truehd") == 0)
++        return av_profile == AV_PROFILE_TRUEHD_ATMOS;
++    return false;
++}
++
+ /* Recompose codec_profile from the engine's live presentation info (Atmos flag,
+  * bed composition, object count, DialNorm) and publish it for the track-info
+  * display. Cheap and idempotent: returns immediately unless the value changed. */
+@@ -356,6 +386,14 @@ static bool ensure_native_child(struct mp_filter *da, struct priv *p)
+     return true;
+ }
+ 
++static void clear_probe_packets(struct priv *p)
++{
++    for (int i = p->probe_packet_pos; i < p->num_probe_packets; i++)
++        mp_frame_unref(&p->probe_packets[i]);
++    p->num_probe_packets = 0;
++    p->probe_packet_pos = 0;
++}
++
+ /* Host mode: pump the native child — forward packets in, decoded frames out. */
+ static void process_host(struct mp_filter *da, struct priv *p)
+ {
+@@ -373,21 +411,40 @@ static void process_host(struct mp_filter *da, struct priv *p)
+         mp_pin_in_write(da->ppins[1], frame);
+     }
+     // Feed input packets to the child.
+-    if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
++    if (p->probe_packet_pos < p->num_probe_packets &&
++        mp_pin_in_needs_data(child_in))
++    {
++        struct mp_frame frame = p->probe_packets[p->probe_packet_pos];
++        p->probe_packets[p->probe_packet_pos++] = MP_NO_FRAME;
++        mp_pin_in_write(child_in, frame);
++        if (p->probe_packet_pos == p->num_probe_packets) {
++            p->num_probe_packets = 0;
++            p->probe_packet_pos = 0;
++        }
++    } else if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
+         struct mp_frame frame = mp_pin_out_read(da->ppins[0]);
+         mp_pin_in_write(child_in, frame);
+     }
+ }
+ 
+ /* Spatial mode: decode + VBAP-render through the engine. */
+-static void process_spatial(struct mp_filter *da, struct priv *p)
++static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_host)
+ {
+     if (!mp_pin_can_transfer_data(da->ppins[1], da->ppins[0]))
+         return;
+ 
+     struct mp_frame inframe = mp_pin_out_read(da->ppins[0]);
+     if (inframe.type == MP_FRAME_EOF) {
+-        mp_pin_in_write(da->ppins[1], inframe);
++        if (probe_host && p->num_probe_packets > 0) {
++            MP_TARRAY_APPEND(p, p->probe_packets, p->num_probe_packets, inframe);
++            p->source_classified = true;
++            p->active_path = PATH_HOST;
++            p->dl->overlay_set_rendering(0);
++            p->dl->overlay_clear();
++            process_host(da, p);
++        } else {
++            mp_pin_in_write(da->ppins[1], inframe);
++        }
+         return;
+     } else if (inframe.type != MP_FRAME_PACKET) {
+         if (inframe.type) {
+@@ -430,6 +487,34 @@ static void process_spatial(struct mp_filter *da, struct priv *p)
+         goto done;
+     }
+ 
++    if (probe_host) {
++        /* Keep ownership of every packet until the bridge can classify the
++         * first decoded presentation. If it is a plain channel stream, replay
++         * these packets into the native decoder so probing loses no audio. */
++        MP_TARRAY_APPEND(p, p->probe_packets, p->num_probe_packets, inframe);
++        inframe = MP_NO_FRAME;
++        mpkt = NULL;
++    }
++
++    int spatial = p->dl->is_spatial(p->renderer);
++    if (spatial == 1) {
++        p->source_spatial = true;
++        p->source_classified = true;
++        clear_probe_packets(p);
++        p->dl->overlay_set_rendering(1);
++    } else if (probe_host && n_frames > 0) {
++        /* The bridge produced a real non-object frame: classification is now
++         * definitive. Discard the probe render and replay from packet zero via
++         * the native child selected for channel-based sources. */
++        p->source_classified = true;
++        p->active_path = PATH_HOST;
++        p->dl->overlay_set_rendering(0);
++        p->dl->overlay_clear();
++        talloc_free(samples);
++        process_host(da, p);
++        return;
++    }
++
+     if (n_frames == 0)
+         goto done;   /* packet consumed; no output yet (need more data) */
+ 
+@@ -546,11 +631,12 @@ static void ad_orender_process(struct mp_filter *da)
+ {
+     struct priv *p = da->priv;
+ 
+-    /* Route on the engine's live channel_render_mode (0 host, 1 spatial), which
+-     * Studio flips over OSC. Reading it per packet is a cheap in-memory call, not
+-     * a poll. `force_host` (engine unusable) pins host. */
++    /* The live channel mode only selects what to do with channel-based sources.
++     * Object content identified by the container or bridge always stays on the
++     * spatial path, independently of Studio's "Spatialize 2D sources" toggle. */
+     int mode = p->renderer ? p->dl->channel_mode(p->renderer) : 0;
+-    bool host = p->force_host || mode != 1;
++    bool probe_host = !p->force_host && !p->source_classified && mode != 1;
++    bool host = p->force_host || (!probe_host && !p->source_spatial && mode != 1);
+     int path = host ? PATH_HOST : PATH_SPATIAL;
+ 
+     /* On a mode flip, flush stale state on the side we switch *to* so it starts
+@@ -584,7 +670,7 @@ static void ad_orender_process(struct mp_filter *da)
+     if (host)
+         process_host(da, p);
+     else
+-        process_spatial(da, p);
++        process_spatial(da, p, probe_host);
+ }
+ 
+ static void ad_orender_reset(struct mp_filter *da)
+@@ -594,6 +680,7 @@ static void ad_orender_reset(struct mp_filter *da)
+         p->dl->reset(p->renderer);
+     if (p->native && p->native->f)
+         mp_filter_reset(p->native->f);
++    clear_probe_packets(p);
+     p->checked_spatial = false;
+     p->active_path = PATH_NONE;
+ }
+@@ -601,6 +688,7 @@ static void ad_orender_reset(struct mp_filter *da)
+ static void ad_orender_destroy(struct mp_filter *da)
+ {
+     struct priv *p = da->priv;
++    clear_probe_packets(p);
+     /* The native child is a talloc child of `da` and is freed with it; the
+      * engine is an FFI handle we must release explicitly. The codec profile
+      * buffer is a talloc child of p->codec (not of `da`), so it correctly
+@@ -642,8 +730,14 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->codec = codec;
+     p->sample_rate = codec->samplerate;
+     p->active_path = PATH_NONE;
++    p->source_spatial = codec_is_spatial_hint(codec);
++    p->source_classified = p->source_spatial;
+     p->public.f = da;
+ 
++    MP_VERBOSE(da, "input profile: %s (early spatial=%s)\n",
++               codec->codec_profile ? codec->codec_profile : "unknown",
++               p->source_spatial ? "yes" : "no");
++
+     struct ad_orender_params *opts =
+         mp_get_config_group(da, da->global, &ad_orender_conf);
+     p->host_decoder_idx = opts->host_decoder_idx;
+@@ -711,8 +805,8 @@ static struct mp_decoder *create(struct mp_filter *parent,
+ 
+     /* Match the overlay's initial visibility to the starting mode, so it does not
+      * flash the wireframe cube before the first packet picks the path. */
+-    bool start_host = p->force_host ||
+-                      !p->renderer || p->dl->channel_mode(p->renderer) != 1;
++    bool start_host = p->force_host || !p->renderer ||
++                      (!p->source_spatial && p->dl->channel_mode(p->renderer) != 1);
+     p->dl->overlay_set_rendering(start_host ? 0 : 1);
+ 
+     /* Official-cased codec name. No "(orender)" suffix: the decoder already shows

--- a/patches/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
+++ b/patches/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
@@ -1,0 +1,115 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 21 Jul 2026 15:43:51 +0200
+Subject: [PATCH 23/24] ad_orender: prefer orender_has_objects (ABI minor 6)
+
+Resolve the object-content probe from the new live-fact symbol
+orender_has_objects, falling back to its deprecated alias
+orender_is_spatial on pre-minor-6 engines (alias resolved first so the
+preferred name overwrites it when both exist). The dl-table field is
+renamed accordingly; vendored orender_abi.h synced (minor 6, updated
+semantics: the value is live, may flip mid-stream, and must not be
+latched beyond the initial host-probe classification).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c |  2 +-
+ common/orender_abi.h      | 14 ++++++++++----
+ common/orender_dl.c       |  8 +++++---
+ common/orender_dl.h       |  5 ++++-
+ 4 files changed, 20 insertions(+), 9 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 15b94c6f49..06c03f0fef 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -496,7 +496,7 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+         mpkt = NULL;
+     }
+ 
+-    int spatial = p->dl->is_spatial(p->renderer);
++    int spatial = p->dl->has_objects(p->renderer);
+     if (spatial == 1) {
+         p->source_spatial = true;
+         p->source_classified = true;
+diff --git a/common/orender_abi.h b/common/orender_abi.h
+index 0cf0c64d8f..a29e268dab 100644
+--- a/common/orender_abi.h
++++ b/common/orender_abi.h
+@@ -35,7 +35,7 @@
+ // C-ABI minor version: backwards-compatible additions only. Consumers should
+ // gate optional features on symbol presence (dlsym), not on this value; it
+ // exists for logging and diagnostics.
+-#define ORENDER_ABI_MINOR 5
++#define ORENDER_ABI_MINOR 6
+ 
+ // Speaker-position labels written by [`orender_channel_layout`] and
+ // [`orender_bed_layout`] (one byte per channel). Mirrors the engine's
+@@ -122,9 +122,15 @@ struct OrenderRenderer *orender_create(const struct OrenderConfig *cfg);
+ // Free a session created by [`orender_create`]. NULL is ignored.
+ void orender_destroy(struct OrenderRenderer *r);
+ 
+-// 1 if the current presentation carries spatial objects, 0 if it is a plain
+-// multichannel stream (the host should fall back to its standard decoder),
+-// <0 on error. Meaningful after at least one [`orender_process`] call.
++// 1 while the current presentation carries dynamic objects, 0 while it is a
++// plain multichannel stream, <0 on error. A live fact: it may flip in either
++// direction mid-stream and must not be latched; before the first decoded
++// frame it reports the bridge's container-level guess. Added in ABI minor 6 —
++// gate on dlsym presence.
++int orender_has_objects(const struct OrenderRenderer *r);
++
++// Deprecated alias of orender_has_objects (pre-minor-6 engines). Same values,
++// same live semantics.
+ int orender_is_spatial(const struct OrenderRenderer *r);
+ 
+ // Dynamic object count of the last rendered frame (decoded channels minus the
+diff --git a/common/orender_dl.c b/common/orender_dl.c
+index c1a182f7ee..1eae97b129 100644
+--- a/common/orender_dl.c
++++ b/common/orender_dl.c
+@@ -77,7 +77,7 @@ static void lib_close(void *handle)
+ 
+ /* ── no-op stubs for optional symbols ─────────────────────────────────────── */
+ 
+-static int stub_is_spatial(const struct OrenderRenderer *r) { return -1; }
++static int stub_has_objects(const struct OrenderRenderer *r) { return -1; }
+ static int stub_set_option(struct OrenderRenderer *r, const char *key,
+                            const char *value) { return -1; }
+ static const char *stub_build_id(void) { return NULL; }
+@@ -132,7 +132,7 @@ static const struct orender_dl stubs = {
+     .object_count = stub_object_count,
+     .dialnorm_db = stub_dialnorm_db,
+     .bed_layout = stub_layout,
+-    .is_spatial = stub_is_spatial,
++    .has_objects = stub_has_objects,
+     .set_option = stub_set_option,
+     .build_id = stub_build_id,
+     .overlay_set_rendering = stub_overlay_set_rendering,
+@@ -291,7 +291,9 @@ static bool try_load(struct mp_log *log, const char *path, const char *origin)
+      * older engine simply lacks the newer features — never a reason to reject. */
+     const struct { const char *name; size_t offset; } optional[] = {
+ #define OPT_SYM(field, sym) {sym, offsetof(struct orender_dl, field)}
+-        OPT_SYM(is_spatial,            "orender_is_spatial"),
++        /* Alias first so the preferred name overwrites it when both exist. */
++        OPT_SYM(has_objects,           "orender_is_spatial"),
++        OPT_SYM(has_objects,           "orender_has_objects"),
+         OPT_SYM(set_option,            "orender_set_option"),
+         OPT_SYM(build_id,              "orender_build_id"),
+         OPT_SYM(overlay_set_rendering, "orender_overlay_set_rendering"),
+diff --git a/common/orender_dl.h b/common/orender_dl.h
+index 6a69de6a57..385aef3bec 100644
+--- a/common/orender_dl.h
++++ b/common/orender_dl.h
+@@ -56,7 +56,10 @@ struct orender_dl {
+                            uint8_t *out_labels, uint32_t cap);
+ 
+     /* optional — stubbed when missing */
+-    int (*is_spatial)(const struct OrenderRenderer *r);
++    /* Resolved from orender_has_objects (ABI minor >= 6), falling back to
++     * its deprecated alias orender_is_spatial on older engines. Live fact:
++     * may flip mid-stream, never latch it. */
++    int (*has_objects)(const struct OrenderRenderer *r);
+     int (*set_option)(struct OrenderRenderer *r, const char *key,
+                       const char *value);
+     const char *(*build_id)(void);

--- a/patches/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
+++ b/patches/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
@@ -1,0 +1,92 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Tue, 21 Jul 2026 18:28:24 +0200
+Subject: [PATCH 24/24] =?UTF-8?q?fix(ad=5Forender):=20DTS:X=20silence=20in?=
+ =?UTF-8?q?=20host=20mode=20=E2=80=94=20classify=20from=20decoded=20frames?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A container-hinted DTS:X track (AV_PROFILE_DTS_HD_MA_X) was latched
+"spatial" at open time, so the probe never ran; the bridge correctly
+reports has_objects=false (a fixed 7.1.4 presentation is channel-based,
+not object content), so in host channel-mode the embedded engine
+returned HostPassthrough — silence — forever, and the native fallback
+never engaged. The only way to get audio was Studio's "Spatialize 2D
+sources" (spatial channel-mode), which routes through the virtual bed.
+
+Root cause: the classification trusted the provisional container hint
+instead of the decoded fact. Three coordinated changes make routing
+follow has_objects, which is a live fact per the channel-object
+contract:
+
+- open time: source_classified starts false (was = the hint), so a
+  hinted track still probes and can fall back to the native decoder;
+- the has_objects==1 branch is gated on n_frames > 0, so a real object
+  stream is only classified spatial from a decoded frame, never from
+  the pre-frame container guess;
+- the host-classify branch clears source_spatial: the decoded fact
+  overrides the hint. Without this, the next packet re-evaluated the
+  routing (host = not source_spatial and ...) with the stale hint still
+  true and bounced back to the spatial path (HostPassthrough silence) —
+  the actual mechanism of the bug.
+
+Verified via PCM capture (Ex Machina DTS:X): host mode now -30.7 dB,
+matching the pure native baseline exactly (was -91 dB silence); spatial
+mode -31.0 dB. No regression: plain DTS 5.1 host -32.5 dB, E-AC3 JOC
+Atmos still classifies spatial and renders in host channel-mode.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 06c03f0fef..9e8b739da1 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -496,16 +496,25 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+         mpkt = NULL;
+     }
+ 
++    /* Classify only from *decoded* frames: before the first frame,
++     * has_objects reports the bridge's container-level guess (e.g. TrueHD
++     * assumes objects until proven otherwise), and latching that guess is
++     * exactly the failure the live-fact contract forbids. */
+     int spatial = p->dl->has_objects(p->renderer);
+-    if (spatial == 1) {
++    if (spatial == 1 && n_frames > 0) {
+         p->source_spatial = true;
+         p->source_classified = true;
+         clear_probe_packets(p);
+         p->dl->overlay_set_rendering(1);
+     } else if (probe_host && n_frames > 0) {
+         /* The bridge produced a real non-object frame: classification is now
+-         * definitive. Discard the probe render and replay from packet zero via
+-         * the native child selected for channel-based sources. */
++         * definitive. The decoded fact overrides the provisional container
++         * hint — this presentation is channel-based, not object content — so
++         * clear source_spatial too, else the next packet's routing
++         * (host = !source_spatial && …) would bounce it back to the spatial
++         * path and render HostPassthrough silence. Discard the probe render
++         * and replay from packet zero via the native child. */
++        p->source_spatial = false;
+         p->source_classified = true;
+         p->active_path = PATH_HOST;
+         p->dl->overlay_set_rendering(0);
+@@ -731,7 +740,14 @@ static struct mp_decoder *create(struct mp_filter *parent,
+     p->sample_rate = codec->samplerate;
+     p->active_path = PATH_NONE;
+     p->source_spatial = codec_is_spatial_hint(codec);
+-    p->source_classified = p->source_spatial;
++    /* The hint is provisional: routing follows the *decoded* fact (the
++     * engine's has_objects is live), so classification only happens once the
++     * bridge has produced frames. A container-profiled DTS:X track whose
++     * presentation is fixed channels (no dynamic objects) must still probe
++     * and fall back to the native path in host mode — terminally trusting
++     * the hint here left the embedded engine passing through silence
++     * forever (channel-object contract, phase 5). */
++    p->source_classified = false;
+     p->public.f = da;
+ 
+     MP_VERBOSE(da, "input profile: %s (early spatial=%s)\n",

--- a/scripts/regenerate-patches.sh
+++ b/scripts/regenerate-patches.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Regenerate patches/ from the mpv fork's `orender` branch.
 #
-# Run this in your mpv fork checkout after committing integration changes on the
-# `orender` branch (branched off the pinned upstream tag/`master`).
+# Run this after committing integration changes on the `orender` branch, which
+# must remain based on the pinned upstream tag.
 #
 # Usage:
 #   scripts/regenerate-patches.sh /path/to/mpv-fork [BASE_REF]
 #
-# BASE_REF defaults to `master` (the upstream mirror branch). See the top-level
-# README for the fork branching workflow.
+# BASE_REF defaults to `v0.41.0`, matching apply-patches.sh. See the top-level
+# README for the stable and live-master fork branching workflows.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/src/ad_orender.c
+++ b/src/ad_orender.c
@@ -9,7 +9,8 @@
  * decoder wrapper in host mode. It stays selected for the whole track and owns
  * the orender engine the whole time, so the engine's OSC listener — and thus the
  * Studio connection — stays alive and keeps receiving the live
- * `channel_render_mode` switch. Each packet is routed on that live mode:
+ * `channel_render_mode` switch. Object content stays on the spatial path;
+ * channel-based content is routed on the live mode:
  *
  *   - spatial : decode + VBAP-render through the engine (objects, or the virtual
  *               bed for plain channel content);
@@ -27,6 +28,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+
+#include <libavcodec/avcodec.h>
 
 #include "mpv_talloc.h"
 #include "audio/aframe.h"
@@ -101,10 +104,15 @@ struct priv {
     struct mp_chmap chmap;
     bool checked_spatial;       // built the output chmap for the spatial path
     int last_mapping;           // last orender_channel_mapping() the chmap was built for (live switch)
+    bool source_spatial;        // container/bridge identified object content
+    bool source_classified;     // first decoded presentation has been inspected
     bool force_host;            // engine unusable (no layout / create failed): always native
     int host_decoder_idx;       // HOST_DEC_LAVC (PCM) or HOST_DEC_SPDIF (passthrough)
     struct mp_decoder *native;  // lazily-created native child decoder for host mode
     int active_path;            // PATH_* of the last packet, for clean transitions
+    struct mp_frame *probe_packets; // packets retained while classifying the source
+    int num_probe_packets;
+    int probe_packet_pos;
     /* Track-info codec profile (shift+I) for the spatial path. Two concerns:
      *
      *  - Lifetime: the core thread reads codec_profile from the track list
@@ -216,6 +224,28 @@ static const char *profile_base(const char *codec, bool has_objects)
     if (strcmp(codec, "dts") == 0)
         return has_objects ? "DTS:X" : "DTS";
     return codec;
+}
+
+/* FFmpeg can expose DTS:X directly in AVCodecParameters.profile, letting the
+ * demuxer identify it before either decoder consumes a packet. Use that early
+ * hint when available; otherwise the retained-packet probe below lets the
+ * bridge classify the presentation without losing the native fallback audio. */
+static bool codec_is_spatial_hint(const struct mp_codec_params *codec)
+{
+    const char *profile = codec->codec_profile;
+    if (profile && (strstr(profile, "DTS:X") || strstr(profile, "Atmos")))
+        return true;
+
+    int av_profile = codec->lav_codecpar ? codec->lav_codecpar->profile
+                                         : AV_PROFILE_UNKNOWN;
+    if (strcmp(codec->codec, "dts") == 0)
+        return av_profile == AV_PROFILE_DTS_HD_MA_X ||
+               av_profile == AV_PROFILE_DTS_HD_MA_X_IMAX;
+    if (strcmp(codec->codec, "eac3") == 0)
+        return av_profile == AV_PROFILE_EAC3_DDP_ATMOS;
+    if (strcmp(codec->codec, "truehd") == 0)
+        return av_profile == AV_PROFILE_TRUEHD_ATMOS;
+    return false;
 }
 
 /* Recompose codec_profile from the engine's live presentation info (Atmos flag,
@@ -356,6 +386,14 @@ static bool ensure_native_child(struct mp_filter *da, struct priv *p)
     return true;
 }
 
+static void clear_probe_packets(struct priv *p)
+{
+    for (int i = p->probe_packet_pos; i < p->num_probe_packets; i++)
+        mp_frame_unref(&p->probe_packets[i]);
+    p->num_probe_packets = 0;
+    p->probe_packet_pos = 0;
+}
+
 /* Host mode: pump the native child — forward packets in, decoded frames out. */
 static void process_host(struct mp_filter *da, struct priv *p)
 {
@@ -373,21 +411,40 @@ static void process_host(struct mp_filter *da, struct priv *p)
         mp_pin_in_write(da->ppins[1], frame);
     }
     // Feed input packets to the child.
-    if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
+    if (p->probe_packet_pos < p->num_probe_packets &&
+        mp_pin_in_needs_data(child_in))
+    {
+        struct mp_frame frame = p->probe_packets[p->probe_packet_pos];
+        p->probe_packets[p->probe_packet_pos++] = MP_NO_FRAME;
+        mp_pin_in_write(child_in, frame);
+        if (p->probe_packet_pos == p->num_probe_packets) {
+            p->num_probe_packets = 0;
+            p->probe_packet_pos = 0;
+        }
+    } else if (mp_pin_can_transfer_data(child_in, da->ppins[0])) {
         struct mp_frame frame = mp_pin_out_read(da->ppins[0]);
         mp_pin_in_write(child_in, frame);
     }
 }
 
 /* Spatial mode: decode + VBAP-render through the engine. */
-static void process_spatial(struct mp_filter *da, struct priv *p)
+static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_host)
 {
     if (!mp_pin_can_transfer_data(da->ppins[1], da->ppins[0]))
         return;
 
     struct mp_frame inframe = mp_pin_out_read(da->ppins[0]);
     if (inframe.type == MP_FRAME_EOF) {
-        mp_pin_in_write(da->ppins[1], inframe);
+        if (probe_host && p->num_probe_packets > 0) {
+            MP_TARRAY_APPEND(p, p->probe_packets, p->num_probe_packets, inframe);
+            p->source_classified = true;
+            p->active_path = PATH_HOST;
+            p->dl->overlay_set_rendering(0);
+            p->dl->overlay_clear();
+            process_host(da, p);
+        } else {
+            mp_pin_in_write(da->ppins[1], inframe);
+        }
         return;
     } else if (inframe.type != MP_FRAME_PACKET) {
         if (inframe.type) {
@@ -428,6 +485,43 @@ static void process_spatial(struct mp_filter *da, struct priv *p)
     if (ret > 0) {
         MP_WARN(da, "orender output buffer too small; dropping packet\n");
         goto done;
+    }
+
+    if (probe_host) {
+        /* Keep ownership of every packet until the bridge can classify the
+         * first decoded presentation. If it is a plain channel stream, replay
+         * these packets into the native decoder so probing loses no audio. */
+        MP_TARRAY_APPEND(p, p->probe_packets, p->num_probe_packets, inframe);
+        inframe = MP_NO_FRAME;
+        mpkt = NULL;
+    }
+
+    /* Classify only from *decoded* frames: before the first frame,
+     * has_objects reports the bridge's container-level guess (e.g. TrueHD
+     * assumes objects until proven otherwise), and latching that guess is
+     * exactly the failure the live-fact contract forbids. */
+    int spatial = p->dl->has_objects(p->renderer);
+    if (spatial == 1 && n_frames > 0) {
+        p->source_spatial = true;
+        p->source_classified = true;
+        clear_probe_packets(p);
+        p->dl->overlay_set_rendering(1);
+    } else if (probe_host && n_frames > 0) {
+        /* The bridge produced a real non-object frame: classification is now
+         * definitive. The decoded fact overrides the provisional container
+         * hint — this presentation is channel-based, not object content — so
+         * clear source_spatial too, else the next packet's routing
+         * (host = !source_spatial && …) would bounce it back to the spatial
+         * path and render HostPassthrough silence. Discard the probe render
+         * and replay from packet zero via the native child. */
+        p->source_spatial = false;
+        p->source_classified = true;
+        p->active_path = PATH_HOST;
+        p->dl->overlay_set_rendering(0);
+        p->dl->overlay_clear();
+        talloc_free(samples);
+        process_host(da, p);
+        return;
     }
 
     if (n_frames == 0)
@@ -546,11 +640,12 @@ static void ad_orender_process(struct mp_filter *da)
 {
     struct priv *p = da->priv;
 
-    /* Route on the engine's live channel_render_mode (0 host, 1 spatial), which
-     * Studio flips over OSC. Reading it per packet is a cheap in-memory call, not
-     * a poll. `force_host` (engine unusable) pins host. */
+    /* The live channel mode only selects what to do with channel-based sources.
+     * Object content identified by the container or bridge always stays on the
+     * spatial path, independently of Studio's "Spatialize 2D sources" toggle. */
     int mode = p->renderer ? p->dl->channel_mode(p->renderer) : 0;
-    bool host = p->force_host || mode != 1;
+    bool probe_host = !p->force_host && !p->source_classified && mode != 1;
+    bool host = p->force_host || (!probe_host && !p->source_spatial && mode != 1);
     int path = host ? PATH_HOST : PATH_SPATIAL;
 
     /* On a mode flip, flush stale state on the side we switch *to* so it starts
@@ -584,7 +679,7 @@ static void ad_orender_process(struct mp_filter *da)
     if (host)
         process_host(da, p);
     else
-        process_spatial(da, p);
+        process_spatial(da, p, probe_host);
 }
 
 static void ad_orender_reset(struct mp_filter *da)
@@ -594,6 +689,7 @@ static void ad_orender_reset(struct mp_filter *da)
         p->dl->reset(p->renderer);
     if (p->native && p->native->f)
         mp_filter_reset(p->native->f);
+    clear_probe_packets(p);
     p->checked_spatial = false;
     p->active_path = PATH_NONE;
 }
@@ -601,6 +697,7 @@ static void ad_orender_reset(struct mp_filter *da)
 static void ad_orender_destroy(struct mp_filter *da)
 {
     struct priv *p = da->priv;
+    clear_probe_packets(p);
     /* The native child is a talloc child of `da` and is freed with it; the
      * engine is an FFI handle we must release explicitly. The codec profile
      * buffer is a talloc child of p->codec (not of `da`), so it correctly
@@ -642,7 +739,20 @@ static struct mp_decoder *create(struct mp_filter *parent,
     p->codec = codec;
     p->sample_rate = codec->samplerate;
     p->active_path = PATH_NONE;
+    p->source_spatial = codec_is_spatial_hint(codec);
+    /* The hint is provisional: routing follows the *decoded* fact (the
+     * engine's has_objects is live), so classification only happens once the
+     * bridge has produced frames. A container-profiled DTS:X track whose
+     * presentation is fixed channels (no dynamic objects) must still probe
+     * and fall back to the native path in host mode — terminally trusting
+     * the hint here left the embedded engine passing through silence
+     * forever (channel-object contract, phase 5). */
+    p->source_classified = false;
     p->public.f = da;
+
+    MP_VERBOSE(da, "input profile: %s (early spatial=%s)\n",
+               codec->codec_profile ? codec->codec_profile : "unknown",
+               p->source_spatial ? "yes" : "no");
 
     struct ad_orender_params *opts =
         mp_get_config_group(da, da->global, &ad_orender_conf);
@@ -711,8 +821,8 @@ static struct mp_decoder *create(struct mp_filter *parent,
 
     /* Match the overlay's initial visibility to the starting mode, so it does not
      * flash the wireframe cube before the first packet picks the path. */
-    bool start_host = p->force_host ||
-                      !p->renderer || p->dl->channel_mode(p->renderer) != 1;
+    bool start_host = p->force_host || !p->renderer ||
+                      (!p->source_spatial && p->dl->channel_mode(p->renderer) != 1);
     p->dl->overlay_set_rendering(start_host ? 0 : 1);
 
     /* Official-cased codec name. No "(orender)" suffix: the decoder already shows


### PR DESCRIPTION
## What changed

- regenerate the pinned `v0.41.0` and live-master patch series from the mpv integration branches
- add the object-routing, live `has_objects`, and decoded-frame classification commits to both series
- synchronize `src/ad_orender.c` with the fork
- correct the stable regeneration documentation so `orender` remains based on `v0.41.0` instead of being rebased onto `master`

## Why

A container spatial-profile hint is provisional. Fixed-channel presentations can decode with `has_objects=false`; permanently trusting the early hint leaves host-mode routing on the embedded spatial path and can produce silence instead of replaying retained packets through the native decoder. The refreshed patch series classifies from decoded frames and lets the live decoded fact override the hint.

Depends on mgth/mpv#9 and mgth/mpv#10. This PR is intentionally draft until those source PRs are merged and the generated provenance is rechecked.

## Validation

- `scripts/apply-patches.sh v0.41.0`
- `scripts/apply-patches-master.sh` against upstream mpv `8c67647b50`
- full Meson compile with `-Dorender=enabled` for both trees
- `mpv --version` smoke test for both trees
- explicit compatible/incompatible runtime ABI stub handshake checks
- applied `audio/decode/ad_orender.c` compared byte-for-byte with the corresponding fork branches
- `bash -n` on patch generation/application scripts
- `git diff --check`