### PR TITLE
chore(release): prepare mpv-omniphony 0.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
   # construction, and removes the stale-prebuilt skew that made mpv silently
   # ship an old liborender (config parsed differently → default room). Bump
   # this one line on each release.
-  OMNIPHONY_REF: v0.4.1
+  OMNIPHONY_REF: v0.4.2
 
 jobs:
   build-linux:


### PR DESCRIPTION
## Summary

- pin the stable player release workflow to Omniphony `v0.4.2`

## Validation

- workflow diff is limited to `OMNIPHONY_REF`
- the current stable patch stack was already validated and merged in #52

## Dependency

Merge #53 first so the beta channel is present on `main`; after that PR lands this release branch will be refreshed and will also pin the tagged beta workflow to Omniphony `v0.4.2`.

Tag only after Omniphony `v0.4.2` exists: source tags `v0.4.2` and `v0.4.2-fel-beta.1`, publishing hub tags `mpv-v0.4.2` and `mpv-v0.4.2-fel-beta.1`.