### PR TITLE
ci: stop gating the pinned liborender build on dead_code

### DIFF
--- a/.github/workflows/build-master-beta.yml
+++ b/.github/workflows/build-master-beta.yml
@@ -105,7 +105,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony/omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Install liborender into sysroot
         run: |
@@ -241,7 +247,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony/omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Install liborender into sysroot
         run: |
@@ -386,7 +398,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage artifact
         shell: pwsh

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -49,7 +49,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony/omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage liborender (bundled fallback)
         # mpv no longer links liborender — it dlopens it at runtime, preferring
@@ -102,7 +108,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage artifact
         shell: pwsh
@@ -342,7 +354,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony/omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage liborender (bundled fallback)
         # Runtime dependency only: mpv dlopens it, preferring a Studio-deployed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony/omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage liborender (bundled fallback)
         # mpv no longer links liborender — it dlopens it at runtime, preferring
@@ -137,7 +143,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage artifact
         shell: pwsh
@@ -451,7 +463,13 @@ jobs:
         run: cargo build --release -p orender_ffi
         working-directory: omniphony/omniphony-renderer
         env:
-          RUSTFLAGS: -D warnings
+          # This builds a *pinned external* source tree (Omniphony at
+          # OMNIPHONY_REF), so lint policy there is not ours to enforce: an
+          # immutable tag must stay buildable as rustc grows new lints.
+          # dead_code in particular fires on liborender's dormant
+          # artifact-evaluator path, which is reachable only through code the
+          # FFI build never links.
+          RUSTFLAGS: -D warnings -A dead_code
 
       - name: Stage liborender (bundled fallback)
         # Runtime dependency only: mpv dlopens it, preferring a Studio-deployed


### PR DESCRIPTION
## Problem

The `v0.4.2` (Release) and `v0.4.2-fel-beta.1` (master-beta) tag builds both failed, on every platform, with:

```
error: fields `x_lut`, `y_lut`, and `z_lut` are never read
error: fields `azimuth_lut`, `elevation_lut`, and `distance_lut` are never read
note: `-D dead-code` implied by `-D warnings`
error: could not compile `renderer` (lib) due to 2 previous errors
```

Nine steps across `release.yml`, `build-master-beta.yml` and `integration-build.yml` compile a **pinned external** source tree — Omniphony at `OMNIPHONY_REF` — under `RUSTFLAGS: -D warnings`. That makes the buildability of an *immutable* Omniphony tag depend on whichever `rustc` the `stable` channel resolves to at build time. rustc 1.97.1 (released 2026-07-14) duly broke it: its dead_code analysis now flags the six `*_lut` fields of `CartesianArtifact` / `PolarArtifact`, whose only readers sit behind `EvaluationArtifactEvaluator` — a dormant path the FFI build never links. rustc 1.94.0 compiles the very same source clean.

## Fix

Allow `dead_code` in those nine steps. Every other warning class stays denied, so a genuine regression in the renderer still fails the release build.

## Verification

Local, rustc 1.97.1, against Omniphony `v0.4.2`:

- `RUSTFLAGS="-D warnings"` → reproduces both errors exactly.
- `RUSTFLAGS="-D warnings -A dead_code"` → builds `liborender.so` (10.3 MB) with **no** warning anywhere in the tree, so `dead_code` was the only 1.97.1 lint standing between us and a green release.

Note that PR CI cannot cover this: `ci.yml` builds against the mock liborender, so only a tag push exercises these steps.

## Follow-up

Once merged, `v0.4.2` and `v0.4.2-fel-beta.1` need to be deleted and re-cut on the new `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)