### PR TITLE
docs: point downloads at the engine repo, publish integration there too

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -453,13 +453,20 @@ jobs:
       # Reset the rolling release + tag so assets are replaced, not accumulated.
       - name: Delete previous integration release + tag (if any)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete integration --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          GH_TOKEN: ${{ secrets.OMNIPHONY_RELEASE_TOKEN }}
+        run: gh release delete mpv-integration --repo mgth/Omniphony --cleanup-tag --yes || true
 
       - name: Publish rolling integration pre-release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: integration
+          # Publish to the engine repo (the download hub), like release.yml and
+          # build-master-beta.yml. The 'mpv-' tag prefix matches neither
+          # Omniphony's v* (Studio) nor liborender-v* triggers, so it starts no
+          # build there. Needs the OMNIPHONY_RELEASE_TOKEN secret
+          # (contents:write on mgth/Omniphony).
+          repository: mgth/Omniphony
+          token: ${{ secrets.OMNIPHONY_RELEASE_TOKEN }}
+          tag_name: mpv-integration
           name: 'mpv-omniphony (integration build)'
           prerelease: true
           make_latest: false

--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ mpv with a **spatial audio decoder** that renders objects through
 instead of letting FFmpeg downmix. **This repository holds the mpv-side
 integration and build only.**
 
+[![Download Omniphony Studio](https://img.shields.io/badge/Download-Omniphony-2ea44f?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/latest)
+[![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.2)
+[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.2-fel-beta.1)
+
 > 📖 **Usage** (playback, Studio supervision, overlay controls) and **prebuilt
 > downloads** live with the engine:
 > **[Omniphony → mpv-omniphony usage guide](https://github.com/mgth/Omniphony/blob/main/docs/mpv-omniphony.md)**.
+> Releases are published on the **engine** repo — this repo carries no downloads.
 
 > ⭐ **mpv-omniphony is one frontend for the
 > [Omniphony](https://github.com/mgth/Omniphony) spatial audio engine — the engine


### PR DESCRIPTION
The engine repo is the single download hub now — `release.yml` and `build-master-beta.yml` already publish to `mgth/Omniphony` under `mpv-v*` tags. This closes the two remaining gaps.

**README** — carries the same download badges as the engine README (Studio · mpv-omniphony · mpv-omniphony FEL), all pointing at `mgth/Omniphony/releases`, plus one line making it explicit that this repo has no downloads of its own.

**`integration-build.yml`** — the rolling `integration` pre-release was the last one still published *here*. It now goes to `mgth/Omniphony` as `mpv-integration`, mirroring `build-master-beta.yml` down to the token and the `mpv-` tag prefix (which triggers neither Omniphony's `v*` Studio build nor `liborender-v*`). The delete-previous step follows it to the engine repo.

Without this second change, drafting the local `integration` release would simply be undone by the next daily run.

Nothing in the workspace references a `mpv-omniphony/releases` URL, so no existing download link breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)