### PR TITLE
ci: build Linux assets with desktop audio/video output backends

### DIFF
--- a/.github/workflows/build-master-beta.yml
+++ b/.github/workflows/build-master-beta.yml
@@ -62,10 +62,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             meson ninja-build pkg-config gcc nasm git patchelf zlib1g-dev \
-            libass-dev liblua5.2-dev libx11-dev \
+            libass-dev liblua5.2-dev \
             libvulkan-dev libshaderc-dev glslang-dev liblcms2-dev \
-            libva-dev libdrm-dev \
-            libbluray-dev libdvdnav-dev libdvdread-dev
+            libva-dev libdrm-dev libegl-dev libgl-dev \
+            libbluray-dev libdvdnav-dev libdvdread-dev \
+            libx11-dev libxss-dev libxext-dev libxpresent-dev libxrandr-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev \
+            libasound2-dev libpipewire-0.3-dev libpulse-dev
+          # x11: libx11-dev alone is NOT enough — mpv's meson x11 feature also
+          # requires xscrnsaver/xext/xpresent/xrandr, and silently disables the
+          # whole X11 vo when any of them is missing (issue #59: assets shipped
+          # with no windowed vo and no audio ao at all).
+          # wayland: client lib + protocols + xkbcommon for vo_gpu on Wayland.
+          # audio: ALSA + PipeWire + PulseAudio aos.
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -151,9 +160,14 @@ jobs:
           #   cuda-hwaccel/-interop -> NVIDIA (ffnvcodec)
           #   vaapi                 -> AMD/Intel (VA-API)
           #   vulkan                -> Vulkan video decode (ffmpeg 8.1, vendor-neutral)
+          # x11/wayland/alsa/pipewire/pulse forced on so a missing dev package
+          # fails the configure instead of silently shipping a binary with no
+          # desktop output backends (issue #59).
           meson setup _b -Dorender=enabled \
             -Dcuda-hwaccel=enabled -Dcuda-interop=enabled \
             -Dvaapi=auto -Dvulkan=enabled \
+            -Dx11=enabled -Dwayland=enabled \
+            -Dalsa=enabled -Dpipewire=enabled -Dpulse=enabled \
             -Dlibbluray=enabled -Ddvdnav=enabled
           meson compile -C _b
           echo "== mpv libplacebo linkage =="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,18 @@ jobs:
           sudo apt-get install -y \
             meson ninja-build pkg-config gcc \
             libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libswscale-dev \
-            libass-dev libplacebo-dev liblua5.2-dev libx11-dev \
+            libass-dev libplacebo-dev liblua5.2-dev \
             libva-dev libdrm-dev libegl-dev libgl-dev \
-            libbluray-dev libdvdnav-dev libdvdread-dev
+            libbluray-dev libdvdnav-dev libdvdread-dev \
+            libx11-dev libxss-dev libxext-dev libxpresent-dev libxrandr-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev \
+            libasound2-dev libpipewire-0.3-dev libpulse-dev
+          # x11: libx11-dev alone is NOT enough — mpv's meson x11 feature also
+          # requires xscrnsaver/xext/xpresent/xrandr, and silently disables the
+          # whole X11 vo when any of them is missing (issue #59: the v0.4.2
+          # Linux asset shipped with no windowed vo and no audio ao at all).
+          # wayland: client lib + protocols + xkbcommon for vo_gpu on Wayland.
+          # audio: ALSA + PipeWire + PulseAudio aos.
 
       - name: Checkout Omniphony (renderer source)
         uses: actions/checkout@v5
@@ -106,9 +115,15 @@ jobs:
           # build FAILS LOUDLY if the dep is missing rather than silently
           # shipping a release without disc support. (dvdnav pulls libdvdread;
           # there is no separate mpv 'dvdread' option.)
+          # x11/wayland/alsa/pipewire/pulse: desktop output backends, forced on
+          # for the same reason — meson's auto features silently drop them when
+          # a dev package is missing, which shipped a v0.4.2 Linux binary that
+          # could only render to files (issue #59).
           meson setup _b -Dorender=enabled \
             -Dcuda-hwaccel=enabled -Dcuda-interop=enabled \
             -Dvaapi=auto \
+            -Dx11=enabled -Dwayland=enabled \
+            -Dalsa=enabled -Dpipewire=enabled -Dpulse=enabled \
             -Dlibbluray=enabled -Ddvdnav=enabled
           meson compile -C _b
 


### PR DESCRIPTION
Fixes #59.

The `mpv-omniphony-v0.4.2-linux-x86_64` release asset shipped with no usable output backends: `--ao=help` listed only `null`/`pcm`, and `--vo=help` had no windowed vo (no x11, no wayland). The binary could only render to files.

## Causes

Both Linux build jobs had the same gap:

1. **No audio output dev packages at all** — `libasound2-dev`, `libpipewire-0.3-dev` and `libpulse-dev` were never installed, and nothing for Wayland either. meson's `auto` features silently dropped every desktop ao/vo.
2. **`libx11-dev` alone does not enable the X11 vo** — mpv's meson `x11` feature also requires `xscrnsaver`, `xext`, `xpresent` and `xrandr` (see `meson.build`), and silently disables the whole feature when any of them is missing. That's why even x11 was absent despite `libx11-dev` being in the apt list.

## Fix

Applied to `release.yml` (stable release assets) and `build-master-beta.yml` (FEL beta Linux bundles, same gap). `build-master.yml` is only a daily patch-drift smoke test that ships no binary, so it is left untouched.

- Install the full set of desktop output dev packages: X11 (`libx11-dev libxss-dev libxext-dev libxpresent-dev libxrandr-dev`), Wayland (`libwayland-dev wayland-protocols libxkbcommon-dev`), audio (`libasound2-dev libpipewire-0.3-dev libpulse-dev`).
- Force `-Dx11=enabled -Dwayland=enabled -Dalsa=enabled -Dpipewire=enabled -Dpulse=enabled` in `meson setup`, so a missing dependency fails the configure loudly instead of silently shipping a mute binary — the same "fail loudly" policy these workflows already apply to `libbluray`/`dvdnav`. This also covers the reporter's suggested `--vo=help`/`--ao=help` smoke test, one step earlier in the pipeline.

After merge, a new tag is needed to republish a working Linux asset — the current v0.4.2 Linux zip is unusable on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)