### PR TITLE
ci: pin mingw-w64-x265 4.1 to match the prebuilt ffmpeg (repo skew)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,22 @@ jobs:
           # build it from source with the embedded udfread in a later step for
           # BD-ISO support. The recursive DLL walker in packaging bundles them.
 
+      - name: Pin mingw-w64-x265 to match the prebuilt ffmpeg (repo skew)
+        run: |
+          # ownstuff is a rolling repo without versioned inter-package deps:
+          # its mingw-w64-ffmpeg 8.1.1 (built 2026-05-12) imports
+          # x265_api_get_215 (x265 4.1), but mingw-w64-x265 moved to 4.2
+          # (API 216) on 2026-07-20, so the current package pair is mutually
+          # broken — mpv.exe fails at startup on the missing x265 entry point.
+          # (This is exactly what broke the v0.4.2 Windows zip, before
+          # check-bundle-imports.py existed to catch it.) Downgrade to the
+          # matching x265 until Martchus rebuilds ffmpeg against x265 >= 4.2;
+          # the "Verify staged DLL imports resolve" step fails loudly when
+          # this pin needs revisiting, in either direction — at that point
+          # just delete this step.
+          pacman -U --noconfirm \
+            https://martchus.no-ip.biz/repo/arch/ownstuff/os/x86_64/mingw-w64-x265-4.1-1-any.pkg.tar.zst
+
       - name: Build & install libsrt from source (ABI-matched to our libstdc++)
         run: |
           # Both the Martchus and the MSYS2 prebuilt libsrt.dll import C++ stdlib


### PR DESCRIPTION
The v0.4.3 release run failed in `build-windows` at the `check-bundle-imports.py` gate:

```
avcodec-62.dll imports x265_api_get_215 from libx265.dll, but the staged libx265.dll does not export it
```

The ownstuff rolling repo currently ships `mingw-w64-ffmpeg` 8.1.1 (built 2026-05-12 against x265 4.1 / API 215) together with `mingw-w64-x265` 4.2 (API 216, built 2026-07-20). The pair is mutually broken — mpv.exe fails at startup on the missing entry point. Note this also means the **v0.4.2 Windows zip is broken the same way**: it was built 2026-07-25 with the skewed pair, hours before the import gate was added.

Fix: downgrade to `mingw-w64-x265-4.1-1` (still served by the repo) right after the pacman install, until Martchus rebuilds ffmpeg against x265 >= 4.2. The import verify step fails loudly when the pin needs revisiting in either direction; at that point the pin step can simply be deleted.

After merge, the `v0.4.3` tag will be moved onto main to rerun the release (nothing was published from the failed run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)