### PR TITLE
ci: trust the pinned x265 package under LocalFileSigLevel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,12 @@ jobs:
           # the "Verify staged DLL imports resolve" step fails loudly when
           # this pin needs revisiting, in either direction — at that point
           # just delete this step.
+          #
+          # The repo section's `SigLevel = Optional TrustAll` does NOT govern
+          # `pacman -U <url>` installs — those use LocalFileSigLevel, which
+          # by default rejects the (unimported) Martchus signature. Extend the
+          # same trust-on-first-use policy to this one file install.
+          sed -i '/^\[options\]/a LocalFileSigLevel = Optional TrustAll' /etc/pacman.conf
           pacman -U --noconfirm \
             https://martchus.no-ip.biz/repo/arch/ownstuff/os/x86_64/mingw-w64-x265-4.1-1-any.pkg.tar.zst
 


### PR DESCRIPTION
Follow-up to #61 — the pin step failed on the v0.4.3 rerun with:

```
error: '/var/cache/pacman/pkg/mingw-w64-x265-4.1-1-any.pkg.tar.zst': invalid or corrupted package (PGP signature)
```

`SigLevel = Optional TrustAll` in the `[ownstuff]` section only governs repo installs; `pacman -U <url>` is governed by `LocalFileSigLevel`, which by default rejects the unimported Martchus signature. This adds `LocalFileSigLevel = Optional TrustAll` before the downgrade — the same trust-on-first-use policy the workflow already applies to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)