### PR TITLE
release: v0.5.0 — sync engine to Omniphony v0.5.0, fix ASIO Int32 crackle

### DIFF
--- a/.github/workflows/build-master-beta.yml
+++ b/.github/workflows/build-master-beta.yml
@@ -34,7 +34,7 @@ on:
 env:
   # Rolling (cron/dispatch/path-push) builds track Omniphony main; a tagged beta
   # pins liborender to the matching release line for reproducibility.
-  OMNIPHONY_REF: ${{ startsWith(github.ref, 'refs/tags/') && 'v0.4.2' || 'main' }}
+  OMNIPHONY_REF: ${{ startsWith(github.ref, 'refs/tags/') && 'v0.5.0' || 'main' }}
 
 jobs:
   # Resolve the live upstream libplacebo master HEAD once so every platform keys
@@ -68,7 +68,8 @@ jobs:
             libbluray-dev libdvdnav-dev libdvdread-dev \
             libx11-dev libxss-dev libxext-dev libxpresent-dev libxrandr-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev \
-            libasound2-dev libpipewire-0.3-dev libpulse-dev
+            libasound2-dev libpipewire-0.3-dev libpulse-dev \
+            libopus-dev
           # x11: libx11-dev alone is NOT enough — mpv's meson x11 feature also
           # requires xscrnsaver/xext/xpresent/xrandr, and silently disables the
           # whole X11 vo when any of them is missing (issue #59: assets shipped
@@ -220,7 +221,8 @@ jobs:
           brew install meson ninja pkg-config cargo-c \
             libass luajit lcms2 shaderc glslang \
             molten-vk vulkan-headers vulkan-loader \
-            libbluray libdvdnav libdvdread
+            libbluray libdvdnav libdvdread \
+            opus
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -461,7 +463,8 @@ jobs:
             mingw-w64-libass \
             mingw-w64-vulkan-headers mingw-w64-vulkan-icd-loader \
             mingw-w64-shaderc mingw-w64-spirv-cross mingw-w64-lcms2 mingw-w64-zlib \
-            mingw-w64-libdvdnav mingw-w64-libdvdread
+            mingw-w64-libdvdnav mingw-w64-libdvdread \
+            mingw-w64-opus
           # ^ DVD playback (folder + ISO) from Martchus; libdvdnav -> libdvdread
           # read images natively. libbluray is built from source with embedded
           # libudfread in a later step (Martchus's lacks udfread = BD folders

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
   # construction, and removes the stale-prebuilt skew that made mpv silently
   # ship an old liborender (config parsed differently → default room). Bump
   # this one line on each release.
-  OMNIPHONY_REF: v0.4.2
+  OMNIPHONY_REF: v0.5.0
 
 jobs:
   build-linux:

--- a/patches-master/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches-master/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/24] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/25] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches-master/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/24] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/25] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches-master/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches-master/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/24] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/25] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches-master/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches-master/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/24] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/25] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches-master/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches-master/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/24] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/25] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches-master/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/24] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/25] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches-master/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/24] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/25] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches-master/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/24] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/25] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches-master/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches-master/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/24] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/25] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches-master/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/24] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/25] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches-master/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches-master/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 13 Jun 2026 11:10:05 +0200
-Subject: [PATCH 11/24] ad_orender: ProgramData config path in the Windows
+Subject: [PATCH 11/25] ad_orender: ProgramData config path in the Windows
  bridge_path hint
 
 The renderer's Windows default config moved to %ProgramData%\omniphony\

--- a/patches-master/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
+++ b/patches-master/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 14:28:27 +0200
-Subject: [PATCH 12/24] ad_orender: host channel-mode fallback to the native
+Subject: [PATCH 12/25] ad_orender: host channel-mode fallback to the native
  decoder
 
 Add --ad-orender-channel-mode (auto/host/direct/virtual) and, in host mode on a

--- a/patches-master/0013-ad_orender-route-DTS-to-orender-too.patch
+++ b/patches-master/0013-ad_orender-route-DTS-to-orender-too.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 16:37:06 +0200
-Subject: [PATCH 13/24] ad_orender: route DTS to orender too
+Subject: [PATCH 13/25] ad_orender: route DTS to orender too
 
 Add "dts" to the codec gate in f_decoder_wrapper (decoder selection) and
 ad_orender (create + add_decoders + codec_desc), so DTS tracks decode through

--- a/patches-master/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
+++ b/patches-master/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 15 Jun 2026 08:14:44 +0200
-Subject: [PATCH 14/24] ad_orender: render AC-3 through orender; fix
+Subject: [PATCH 14/25] ad_orender: render AC-3 through orender; fix
  channel-mode option
 
 - Offer the orender decoder for the `ac3` codec (in addition to truehd,

--- a/patches-master/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
+++ b/patches-master/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:25:41 +0200
-Subject: [PATCH 15/24] feat(ad_orender): keep the engine alive in host mode;
+Subject: [PATCH 15/25] feat(ad_orender): keep the engine alive in host mode;
  live spatial<->host
 
 ad_orender is now the persistent decoder for the supported codecs and

--- a/patches-master/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
+++ b/patches-master/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:35:47 +0200
-Subject: [PATCH 16/24] feat(ad_orender): hide the spatial overlay in host mode
+Subject: [PATCH 16/25] feat(ad_orender): hide the spatial overlay in host mode
 
 When routing channel audio to the native host decoder, suppress the whole
 spatial overlay (wireframe cube included) via orender_overlay_set_rendering(0)

--- a/patches-master/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
+++ b/patches-master/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 23:47:09 +0200
-Subject: [PATCH 17/24] feat(ad_orender): show Atmos profile, bed+objects and
+Subject: [PATCH 17/25] feat(ad_orender): show Atmos profile, bed+objects and
  DialNorm in track info
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
+++ b/patches-master/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 08:25:51 +0200
-Subject: [PATCH 18/24] fix(ad_orender): label track profile from decoded
+Subject: [PATCH 18/25] fix(ad_orender): label track profile from decoded
  objects, not is_spatial
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
+++ b/patches-master/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 18:51:09 +0200
-Subject: [PATCH 19/24] feat(ad_orender): honor renderer output channel mapping
+Subject: [PATCH 19/25] feat(ad_orender): honor renderer output channel mapping
  (by-index/by-name), live
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
+++ b/patches-master/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 20 Jun 2026 21:55:59 +0200
-Subject: [PATCH 20/24] fix(ad_orender): anchor codec_profile buffer to codec
+Subject: [PATCH 20/25] fix(ad_orender): anchor codec_profile buffer to codec
  lifetime
 
 codec_profile was published from p->profile_buf, which lived inline in

--- a/patches-master/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
+++ b/patches-master/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 2 Jul 2026 17:35:46 +0200
-Subject: [PATCH 21/24] ad_orender: load liborender at runtime with an ABI
+Subject: [PATCH 21/25] ad_orender: load liborender at runtime with an ABI
  handshake
 
 mpv linked liborender at build time (DT_NEEDED liborender.so.0), which

--- a/patches-master/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
+++ b/patches-master/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 20 Jul 2026 18:23:18 +0200
-Subject: [PATCH 22/24] fix(ad): keep object content on spatial renderer
+Subject: [PATCH 22/25] fix(ad): keep object content on spatial renderer
 
 ---
  audio/decode/ad_orender.c | 116 ++++++++++++++++++++++++++++++++++----

--- a/patches-master/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
+++ b/patches-master/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 21 Jul 2026 15:43:51 +0200
-Subject: [PATCH 23/24] ad_orender: prefer orender_has_objects (ABI minor 6)
+Subject: [PATCH 23/25] ad_orender: prefer orender_has_objects (ABI minor 6)
 
 Resolve the object-content probe from the new live-fact symbol
 orender_has_objects, falling back to its deprecated alias

--- a/patches-master/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
+++ b/patches-master/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 21 Jul 2026 18:28:24 +0200
-Subject: [PATCH 24/24] =?UTF-8?q?fix(ad=5Forender):=20DTS:X=20silence=20in?=
+Subject: [PATCH 24/25] =?UTF-8?q?fix(ad=5Forender):=20DTS:X=20silence=20in?=
  =?UTF-8?q?=20host=20mode=20=E2=80=94=20classify=20from=20decoded=20frames?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches-master/0025-fix-ao_asio-full-scale-samples-wrapped-to-INT32_MIN-.patch
+++ b/patches-master/0025-fix-ao_asio-full-scale-samples-wrapped-to-INT32_MIN-.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Sat, 15 Aug 2026 22:04:59 +0200
+Subject: [PATCH 25/25] fix(ao_asio): full-scale samples wrapped to INT32_MIN
+ on Int32 output
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+2147483647 has no float32 representation: the scale constant rounds up to
+2^31, so lrintf() of a clamped +1.0f sample overflows the 32-bit long and
+comes back as INT32_MIN — a full-scale polarity flip on every clipped or
+exactly-full-scale peak, audible as loud crackling on loud passages.
+
+This is why forcing --ad=libopus "fixed" opus playback over ASIO: the
+libopus wrapper decodes to s16, whose float conversion tops out at
+32767/32768 and never reaches the wrapping input. The native ffmpeg opus
+decoder outputs float that clips at exactly 1.0f and wrapped every peak.
+WASAPI was unaffected because it does not use this conversion path.
+
+Scale in double instead, where INT32_MAX is exact and the rounded result
+always fits.
+
+Fixes mgth/mpv-omniphony#64
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/out/ao_asio.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/audio/out/ao_asio.c b/audio/out/ao_asio.c
+index c215e10337..bda51a6fca 100644
+--- a/audio/out/ao_asio.c
++++ b/audio/out/ao_asio.c
+@@ -132,8 +132,12 @@ static void conv_s32(void *dst, const float *src, int n, float vol)
+ {
+     (void)vol;
+     int32_t *d = dst;
++    // 2147483647 is not representable as float: scaling by 2147483647.0f
++    // rounds full scale to 2^31, and lrintf() of that overflows the 32-bit
++    // long, turning +1.0f into INT32_MIN — a full-scale polarity flip on
++    // every clipped peak. Scale in double, where INT32_MAX is exact.
+     for (int i = 0; i < n; i++)
+-        d[i] = (int32_t)lrintf(clampf(src[i]) * 2147483647.0f);
++        d[i] = (int32_t)lrint(clampf(src[i]) * 2147483647.0);
+ }
+ 
+ static void conv_s24(void *dst, const float *src, int n, float vol)

--- a/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
+++ b/patches/0001-audio-add-ad_orender-spatial-audio-decoder-via-libor.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:48:20 +0200
-Subject: [PATCH 01/24] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
+Subject: [PATCH 01/26] =?UTF-8?q?audio:=20add=20ad=5Forender=20=E2=80=94?=
  =?UTF-8?q?=20spatial=20audio=20decoder=20via=20liborender?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
+++ b/patches/0002-ao-asio-add-Steinberg-ASIO-audio-output-driver.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 12:50:45 +0200
-Subject: [PATCH 02/24] ao/asio: add Steinberg ASIO audio output driver
+Subject: [PATCH 02/26] ao/asio: add Steinberg ASIO audio output driver
 
 Add ao_asio, a pull-style audio output for mpv targeting Steinberg ASIO
 drivers on Windows. The driver:

--- a/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
+++ b/patches/0003-ci-add-Windows-ASIO-build-workflow.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 14:58:45 +0200
-Subject: [PATCH 03/24] ci: add Windows ASIO build workflow
+Subject: [PATCH 03/26] ci: add Windows ASIO build workflow
 
 Add a dedicated GitHub Actions workflow that builds the ASIO-enabled
 mpv on Windows under MSYS2 UCRT64. The existing build.yml only fires

--- a/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
+++ b/patches/0004-ao-asio-fix-asio-option-prefix-in-error-message-and-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 15:32:46 +0200
-Subject: [PATCH 04/24] ao/asio: fix --asio-* option prefix in error message
+Subject: [PATCH 04/26] ao/asio: fix --asio-* option prefix in error message
  and comment
 
 The driver name is `asio`, and the m_option entries use

--- a/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
+++ b/patches/0005-ao-asio-advertise-waveext-any-chmap-so-7.1.4-9.1.6-o.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 20:09:02 +0200
-Subject: [PATCH 05/24] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
+Subject: [PATCH 05/26] ao/asio: advertise waveext + any-chmap so 7.1.4/9.1.6
  outputs aren't downmixed
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
+++ b/patches/0006-ao-wasapi-advertise-5.1.4-7.1.4-9.1.6-in-the-exclusi.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:03:01 +0200
-Subject: [PATCH 06/24] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
+Subject: [PATCH 06/26] ao/wasapi: advertise 5.1.4 / 7.1.4 / 9.1.6 in the
  exclusive layout search
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
+++ b/patches/0007-ao-wasapi-also-probe-discrete-N-17.MP_NUM_CHANNELS-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 26 May 2026 22:11:54 +0200
-Subject: [PATCH 07/24] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
+Subject: [PATCH 07/26] ao/wasapi: also probe discrete N=17..MP_NUM_CHANNELS
  for pro devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
+++ b/patches/0008-ad_orender-renegotiate-the-chmap-on-output-channel-c.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 11 Jun 2026 13:37:57 +0200
-Subject: [PATCH 08/24] ad_orender: renegotiate the chmap on output
+Subject: [PATCH 08/26] ad_orender: renegotiate the chmap on output
  channel-count changes
 
 Studio can switch the renderer's output mode (binaural stereo vs

--- a/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
+++ b/patches/0009-player-built-in-spatial-overlay-client-replaces-omni.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:23:29 +0200
-Subject: [PATCH 09/24] player: built-in spatial overlay client (replaces
+Subject: [PATCH 09/26] player: built-in spatial overlay client (replaces
  omniphony-overlay.lua)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
+++ b/patches/0010-ad_orender-use-the-per-OS-config-path-in-the-bridge_.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 12 Jun 2026 09:27:00 +0200
-Subject: [PATCH 10/24] ad_orender: use the per-OS config path in the
+Subject: [PATCH 10/26] ad_orender: use the per-OS config path in the
  bridge_path hint
 
 Back-port of mpv-omniphony commit 2df2800, which was applied to the

--- a/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
+++ b/patches/0011-ad_orender-ProgramData-config-path-in-the-Windows-br.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 13 Jun 2026 11:10:05 +0200
-Subject: [PATCH 11/24] ad_orender: ProgramData config path in the Windows
+Subject: [PATCH 11/26] ad_orender: ProgramData config path in the Windows
  bridge_path hint
 
 The renderer's Windows default config moved to %ProgramData%\omniphony\

--- a/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
+++ b/patches/0012-ad_orender-host-channel-mode-fallback-to-the-native-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 14:28:27 +0200
-Subject: [PATCH 12/24] ad_orender: host channel-mode fallback to the native
+Subject: [PATCH 12/26] ad_orender: host channel-mode fallback to the native
  decoder
 
 Add --ad-orender-channel-mode (auto/host/direct/virtual) and, in host mode on a

--- a/patches/0013-ad_orender-route-DTS-to-orender-too.patch
+++ b/patches/0013-ad_orender-route-DTS-to-orender-too.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sun, 14 Jun 2026 16:37:06 +0200
-Subject: [PATCH 13/24] ad_orender: route DTS to orender too
+Subject: [PATCH 13/26] ad_orender: route DTS to orender too
 
 Add "dts" to the codec gate in f_decoder_wrapper (decoder selection) and
 ad_orender (create + add_decoders + codec_desc), so DTS tracks decode through

--- a/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
+++ b/patches/0014-ad_orender-render-AC-3-through-orender-fix-channel-m.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 15 Jun 2026 08:14:44 +0200
-Subject: [PATCH 14/24] ad_orender: render AC-3 through orender; fix
+Subject: [PATCH 14/26] ad_orender: render AC-3 through orender; fix
  channel-mode option
 
 - Offer the orender decoder for the `ac3` codec (in addition to truehd,

--- a/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
+++ b/patches/0015-feat-ad_orender-keep-the-engine-alive-in-host-mode-l.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:25:41 +0200
-Subject: [PATCH 15/24] feat(ad_orender): keep the engine alive in host mode;
+Subject: [PATCH 15/26] feat(ad_orender): keep the engine alive in host mode;
  live spatial<->host
 
 ad_orender is now the persistent decoder for the supported codecs and

--- a/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
+++ b/patches/0016-feat-ad_orender-hide-the-spatial-overlay-in-host-mod.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 08:35:47 +0200
-Subject: [PATCH 16/24] feat(ad_orender): hide the spatial overlay in host mode
+Subject: [PATCH 16/26] feat(ad_orender): hide the spatial overlay in host mode
 
 When routing channel audio to the native host decoder, suppress the whole
 spatial overlay (wireframe cube included) via orender_overlay_set_rendering(0)

--- a/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
+++ b/patches/0017-feat-ad_orender-show-Atmos-profile-bed-objects-and-D.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 16 Jun 2026 23:47:09 +0200
-Subject: [PATCH 17/24] feat(ad_orender): show Atmos profile, bed+objects and
+Subject: [PATCH 17/26] feat(ad_orender): show Atmos profile, bed+objects and
  DialNorm in track info
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
+++ b/patches/0018-fix-ad_orender-label-track-profile-from-decoded-obje.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 08:25:51 +0200
-Subject: [PATCH 18/24] fix(ad_orender): label track profile from decoded
+Subject: [PATCH 18/26] fix(ad_orender): label track profile from decoded
  objects, not is_spatial
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
+++ b/patches/0019-feat-ad_orender-honor-renderer-output-channel-mappin.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Fri, 19 Jun 2026 18:51:09 +0200
-Subject: [PATCH 19/24] feat(ad_orender): honor renderer output channel mapping
+Subject: [PATCH 19/26] feat(ad_orender): honor renderer output channel mapping
  (by-index/by-name), live
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
+++ b/patches/0020-fix-ad_orender-anchor-codec_profile-buffer-to-codec-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Sat, 20 Jun 2026 21:55:59 +0200
-Subject: [PATCH 20/24] fix(ad_orender): anchor codec_profile buffer to codec
+Subject: [PATCH 20/26] fix(ad_orender): anchor codec_profile buffer to codec
  lifetime
 
 codec_profile was published from p->profile_buf, which lived inline in

--- a/patches/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
+++ b/patches/0021-ad_orender-load-liborender-at-runtime-with-an-ABI-ha.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Thu, 2 Jul 2026 17:35:46 +0200
-Subject: [PATCH 21/24] ad_orender: load liborender at runtime with an ABI
+Subject: [PATCH 21/26] ad_orender: load liborender at runtime with an ABI
  handshake
 
 mpv linked liborender at build time (DT_NEEDED liborender.so.0), which

--- a/patches/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
+++ b/patches/0022-fix-ad-keep-object-content-on-spatial-renderer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Mon, 20 Jul 2026 18:23:18 +0200
-Subject: [PATCH 22/24] fix(ad): keep object content on spatial renderer
+Subject: [PATCH 22/26] fix(ad): keep object content on spatial renderer
 
 ---
  audio/decode/ad_orender.c | 116 ++++++++++++++++++++++++++++++++++----

--- a/patches/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
+++ b/patches/0023-ad_orender-prefer-orender_has_objects-ABI-minor-6.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 21 Jul 2026 15:43:51 +0200
-Subject: [PATCH 23/24] ad_orender: prefer orender_has_objects (ABI minor 6)
+Subject: [PATCH 23/26] ad_orender: prefer orender_has_objects (ABI minor 6)
 
 Resolve the object-content probe from the new live-fact symbol
 orender_has_objects, falling back to its deprecated alias

--- a/patches/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
+++ b/patches/0024-fix-ad_orender-DTS-X-silence-in-host-mode-classify-f.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mathieu GRENET <mathieu@mgth.fr>
 Date: Tue, 21 Jul 2026 18:28:24 +0200
-Subject: [PATCH 24/24] =?UTF-8?q?fix(ad=5Forender):=20DTS:X=20silence=20in?=
+Subject: [PATCH 24/26] =?UTF-8?q?fix(ad=5Forender):=20DTS:X=20silence=20in?=
  =?UTF-8?q?=20host=20mode=20=E2=80=94=20classify=20from=20decoded=20frames?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/patches/0025-ad_orender-size-the-scratch-for-the-widest-layout-no.patch
+++ b/patches/0025-ad_orender-size-the-scratch-for-the-widest-layout-no.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <sub@mgth.fr>
+Date: Fri, 14 Aug 2026 20:58:23 +0200
+Subject: [PATCH 25/26] ad_orender: size the scratch for the widest layout, not
+ the current mode (#12)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+An output-mode switch can land inside orender_process(), which then decodes
+into the *new* mode. The scratch was sized from the channel count queried just
+before the call, so a flip to speakers left a binaural-sized buffer too small:
+the call returned "buffer too small" and the packet was dropped — audible as a
+plop on the switch.
+
+Retrying is not an option. By the time orender_process finds the buffer short
+it has already decoded the packet and discarded the chunks; calling again with
+the same packet would advance the bridge twice. The buffer has to be large
+enough beforehand.
+
+Keep a high-water mark of the widest layout the stream has produced and size
+the scratch from that, never shrinking back. On the one path that can still be
+caught short — the first time a stream widens — raise the mark from what the
+renderer reports, so it costs a single packet once rather than one per switch.
+
+Also bound the copy against the scratch it reads from. The (n_frames, n_ch)
+pair comes back across the FFI and sizes a memcpy out of a buffer we allocated;
+a report exceeding what the call was allowed to fill would read past the end
+and play adjacent heap as PCM. A renderer-side race made exactly that happen
+(fixed there), so this stays as a cheap guard on the trust boundary.
+
+Verified over 157 live mode flips through a real decode: 5 dropped packets
+before, 0 after, and no warnings from the guard.
+
+Co-authored-by: Claude <noreply@anthropic.com>
+---
+ audio/decode/ad_orender.c | 35 +++++++++++++++++++++++++++++++++--
+ 1 file changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/audio/decode/ad_orender.c b/audio/decode/ad_orender.c
+index 9e8b739da1..1842cb2386 100644
+--- a/audio/decode/ad_orender.c
++++ b/audio/decode/ad_orender.c
+@@ -104,6 +104,13 @@ struct priv {
+     struct mp_chmap chmap;
+     bool checked_spatial;       // built the output chmap for the spatial path
+     int last_mapping;           // last orender_channel_mapping() the chmap was built for (live switch)
++    /* Widest output layout this stream has produced. The scratch is sized from
++     * this rather than from the mode we are nominally in: an output-mode switch
++     * can land inside orender_process(), which then decodes into the NEW mode,
++     * and a buffer sized for binaural stereo is then too small for a speaker
++     * frame. That returned "buffer too small" and we dropped the packet —
++     * audible as a plop on the switch. */
++    int scratch_ch_hwm;
+     bool source_spatial;        // container/bridge identified object content
+     bool source_classified;     // first decoded presentation has been inspected
+     bool force_host;            // engine unusable (no layout / create failed): always native
+@@ -466,7 +473,10 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+     if (cur_ch > 0 && cur_ch <= MP_NUM_CHANNELS && (int)cur_ch != p->channels)
+         p->channels = (int)cur_ch;
+     int ch = p->channels > 0 ? p->channels : 1;
+-    size_t capacity = (size_t)4096 * (size_t)ch;
++    /* Never shrink back to the current mode's width — see scratch_ch_hwm. */
++    if (ch > p->scratch_ch_hwm)
++        p->scratch_ch_hwm = ch;
++    size_t capacity = (size_t)4096 * (size_t)p->scratch_ch_hwm;
+     float *samples = talloc_array(NULL, float, capacity);
+ 
+     uintptr_t n_frames = 0;
+@@ -483,7 +493,16 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+         goto done;
+     }
+     if (ret > 0) {
+-        MP_WARN(da, "orender output buffer too small; dropping packet\n");
++        /* Retrying is not possible: orender_process has already decoded this
++         * packet by the time it finds the buffer short, so calling again would
++         * advance the bridge twice. Raise the mark to the width the renderer
++         * reports now, so this costs one packet the first time a stream widens
++         * and nothing on later switches. */
++        uint32_t now_ch = p->dl->channel_count(p->renderer);
++        if (now_ch > 0 && now_ch <= MP_NUM_CHANNELS && (int)now_ch > p->scratch_ch_hwm)
++            p->scratch_ch_hwm = (int)now_ch;
++        MP_WARN(da, "orender output buffer too small (sized for %d ch, renderer "
++                    "reports %u ch); dropping packet\n", ch, now_ch);
+         goto done;
+     }
+ 
+@@ -527,6 +546,18 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
+     if (n_frames == 0)
+         goto done;   /* packet consumed; no output yet (need more data) */
+ 
++    /* The copy at the end of this function is sized from the (n_frames, n_ch)
++     * orender_process reports, but reads out of `samples`, which we allocated.
++     * Bound it: a report exceeding what the call was allowed to fill would read
++     * past the scratch and play adjacent heap as PCM. A renderer bug made
++     * exactly that happen (a mode switch racing the channel count), so this
++     * stays as a cheap guard on a memcpy that crosses the FFI trust boundary. */
++    if ((size_t)n_frames * (size_t)n_ch > capacity) {
++        MP_ERR(da, "orender reported %zu frames x %u ch from a %zu-float "
++                   "buffer; dropping frame\n", (size_t)n_frames, n_ch, capacity);
++        goto done;
++    }
++
+     /* Resolve the output chmap on the first *decoded* frame. Deferred until
+      * n_frames > 0: the layout is only meaningful once the bridge has decoded a
+      * frame (AC-3/DTS need several packets to acquire sync). */

--- a/patches/0026-fix-ao_asio-full-scale-samples-wrapped-to-INT32_MIN-.patch
+++ b/patches/0026-fix-ao_asio-full-scale-samples-wrapped-to-INT32_MIN-.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathieu GRENET <mathieu@mgth.fr>
+Date: Sat, 15 Aug 2026 22:04:59 +0200
+Subject: [PATCH 26/26] fix(ao_asio): full-scale samples wrapped to INT32_MIN
+ on Int32 output
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+2147483647 has no float32 representation: the scale constant rounds up to
+2^31, so lrintf() of a clamped +1.0f sample overflows the 32-bit long and
+comes back as INT32_MIN — a full-scale polarity flip on every clipped or
+exactly-full-scale peak, audible as loud crackling on loud passages.
+
+This is why forcing --ad=libopus "fixed" opus playback over ASIO: the
+libopus wrapper decodes to s16, whose float conversion tops out at
+32767/32768 and never reaches the wrapping input. The native ffmpeg opus
+decoder outputs float that clips at exactly 1.0f and wrapped every peak.
+WASAPI was unaffected because it does not use this conversion path.
+
+Scale in double instead, where INT32_MAX is exact and the rounded result
+always fits.
+
+Fixes mgth/mpv-omniphony#64
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ audio/out/ao_asio.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/audio/out/ao_asio.c b/audio/out/ao_asio.c
+index c215e10337..bda51a6fca 100644
+--- a/audio/out/ao_asio.c
++++ b/audio/out/ao_asio.c
+@@ -132,8 +132,12 @@ static void conv_s32(void *dst, const float *src, int n, float vol)
+ {
+     (void)vol;
+     int32_t *d = dst;
++    // 2147483647 is not representable as float: scaling by 2147483647.0f
++    // rounds full scale to 2^31, and lrintf() of that overflows the 32-bit
++    // long, turning +1.0f into INT32_MIN — a full-scale polarity flip on
++    // every clipped peak. Scale in double, where INT32_MAX is exact.
+     for (int i = 0; i < n; i++)
+-        d[i] = (int32_t)lrintf(clampf(src[i]) * 2147483647.0f);
++        d[i] = (int32_t)lrint(clampf(src[i]) * 2147483647.0);
+ }
+ 
+ static void conv_s24(void *dst, const float *src, int n, float vol)

--- a/scripts/build-fel-deps.sh
+++ b/scripts/build-fel-deps.sh
@@ -185,8 +185,11 @@ fi
 git -C "$WORK/ffmpeg" reset --hard -q "origin/${FFMPEG_REF##*/}" 2>/dev/null || true
 git -C "$WORK/ffmpeg" clean -fdx >/dev/null 2>&1 || true
 
+# libopus: the wrapper decoder must be available as a fallback next to the
+# native opus decoder (mpv-omniphony#64 shipped FEL bundles without it).
 ff_args=(--prefix="$PREFIX" --enable-shared --disable-static
-         --enable-gpl --enable-version3 --disable-doc)
+         --enable-gpl --enable-version3 --disable-doc
+         --enable-libopus)
 # NVIDIA nvdec/cuvid only where NVIDIA exists; macOS auto-detects VideoToolbox
 # instead, which is fine — FEL needs only the dovi_split BSF + libdovi.
 [ "$MACOS" = 1 ] || ff_args+=(--enable-ffnvcodec --enable-nvdec --enable-cuvid)

--- a/src/ad_orender.c
+++ b/src/ad_orender.c
@@ -104,6 +104,13 @@ struct priv {
     struct mp_chmap chmap;
     bool checked_spatial;       // built the output chmap for the spatial path
     int last_mapping;           // last orender_channel_mapping() the chmap was built for (live switch)
+    /* Widest output layout this stream has produced. The scratch is sized from
+     * this rather than from the mode we are nominally in: an output-mode switch
+     * can land inside orender_process(), which then decodes into the NEW mode,
+     * and a buffer sized for binaural stereo is then too small for a speaker
+     * frame. That returned "buffer too small" and we dropped the packet —
+     * audible as a plop on the switch. */
+    int scratch_ch_hwm;
     bool source_spatial;        // container/bridge identified object content
     bool source_classified;     // first decoded presentation has been inspected
     bool force_host;            // engine unusable (no layout / create failed): always native
@@ -466,7 +473,10 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
     if (cur_ch > 0 && cur_ch <= MP_NUM_CHANNELS && (int)cur_ch != p->channels)
         p->channels = (int)cur_ch;
     int ch = p->channels > 0 ? p->channels : 1;
-    size_t capacity = (size_t)4096 * (size_t)ch;
+    /* Never shrink back to the current mode's width — see scratch_ch_hwm. */
+    if (ch > p->scratch_ch_hwm)
+        p->scratch_ch_hwm = ch;
+    size_t capacity = (size_t)4096 * (size_t)p->scratch_ch_hwm;
     float *samples = talloc_array(NULL, float, capacity);
 
     uintptr_t n_frames = 0;
@@ -483,7 +493,16 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
         goto done;
     }
     if (ret > 0) {
-        MP_WARN(da, "orender output buffer too small; dropping packet\n");
+        /* Retrying is not possible: orender_process has already decoded this
+         * packet by the time it finds the buffer short, so calling again would
+         * advance the bridge twice. Raise the mark to the width the renderer
+         * reports now, so this costs one packet the first time a stream widens
+         * and nothing on later switches. */
+        uint32_t now_ch = p->dl->channel_count(p->renderer);
+        if (now_ch > 0 && now_ch <= MP_NUM_CHANNELS && (int)now_ch > p->scratch_ch_hwm)
+            p->scratch_ch_hwm = (int)now_ch;
+        MP_WARN(da, "orender output buffer too small (sized for %d ch, renderer "
+                    "reports %u ch); dropping packet\n", ch, now_ch);
         goto done;
     }
 
@@ -526,6 +545,18 @@ static void process_spatial(struct mp_filter *da, struct priv *p, bool probe_hos
 
     if (n_frames == 0)
         goto done;   /* packet consumed; no output yet (need more data) */
+
+    /* The copy at the end of this function is sized from the (n_frames, n_ch)
+     * orender_process reports, but reads out of `samples`, which we allocated.
+     * Bound it: a report exceeding what the call was allowed to fill would read
+     * past the scratch and play adjacent heap as PCM. A renderer bug made
+     * exactly that happen (a mode switch racing the channel count), so this
+     * stays as a cheap guard on a memcpy that crosses the FFI trust boundary. */
+    if ((size_t)n_frames * (size_t)n_ch > capacity) {
+        MP_ERR(da, "orender reported %zu frames x %u ch from a %zu-float "
+                   "buffer; dropping frame\n", (size_t)n_frames, n_ch, capacity);
+        goto done;
+    }
 
     /* Resolve the output chmap on the first *decoded* frame. Deferred until
      * n_frames > 0: the layout is only meaningful once the bridge has decoded a


### PR DESCRIPTION
Prepares the v0.5.0 release, synced with Omniphony v0.5.0 (engine + Studio released today).

- `OMNIPHONY_REF` → `v0.5.0` (stable bundle + tagged-beta pin).
- `patches/` + `patches-master/` regenerated from the fork: includes mgth/mpv#13 — the ao_asio Int32 conversion wrapped full-scale samples to `INT32_MIN` (root cause of #64) — plus the ad_orender scratch-sizing and DTS:X host-mode fixes already on the fork.
- `src/ad_orender.c` synced.
- FEL/master bundles: ffmpeg built with `--enable-libopus` (+ per-OS deps) — the shipped FEL builds had no libopus decoder at all (second finding of #64).

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)