### PR TITLE
fix(fel-deps): clone ffmpeg from the official GitHub mirror

### DIFF
--- a/deps-fel/pins-fel.env
+++ b/deps-fel/pins-fel.env
@@ -18,7 +18,7 @@ LIBPLACEBO_REF="master"
 # the AV_STREAM_GROUP_PARAMS_DOLBY_VISION stream group that mpv's demux/dovi_split
 # and demux_lavf now rely on. release/8.1 has NEITHER, so master is required until
 # an ffmpeg release ships them. The vendored dovi_split patch is gone (upstream).
-FFMPEG_URL="https://git.ffmpeg.org/ffmpeg.git"
+FFMPEG_URL="https://github.com/FFmpeg/FFmpeg.git"
 FFMPEG_REF="master"
 
 # NB: the mpv base is no longer pinned. The old MPV_FEL_BASE pin existed only to


### PR DESCRIPTION
git.ffmpeg.org answers 'repository not found' right now (verified from the CI runners and locally), which failed all three platform jobs of the v0.5.0-fel-beta.1 build at the ffmpeg clone. Switch `FFMPEG_URL` to the official GitHub mirror — same content, sturdier hosting. A v0.5.0-fel-beta.2 tag will follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)