### PR TITLE
fix(fel-ci): build wayland 1.23 + wayland-protocols 1.41 into the FEL prefix

### DIFF
--- a/.github/workflows/build-master-beta.yml
+++ b/.github/workflows/build-master-beta.yml
@@ -69,7 +69,8 @@ jobs:
             libx11-dev libxss-dev libxext-dev libxpresent-dev libxrandr-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev \
             libasound2-dev libpipewire-0.3-dev libpulse-dev \
-            libopus-dev
+            libopus-dev \
+            libffi-dev libexpat1-dev
           # x11: libx11-dev alone is NOT enough — mpv's meson x11 feature also
           # requires xscrnsaver/xext/xpresent/xrandr, and silently disables the
           # whole X11 vo when any of them is missing (issue #59: assets shipped
@@ -103,6 +104,32 @@ jobs:
           pkg-config --atleast-version=7.370 libplacebo
           echo "libplacebo $(pkg-config --modversion libplacebo)"
           ffmpeg -hide_banner -bsfs | grep -q dovi_split
+
+      # mpv master needs wayland-client/-cursor/-scanner >= 1.23 and
+      # wayland-protocols >= 1.38; noble ships 1.22 / 1.34. Build both into the
+      # FEL prefix (PKG_CONFIG_PATH/PATH already point there for the mpv build,
+      # and the bundler stages prefix libs). Runs on cache hits too — the
+      # pkg-config guard makes it a no-op once the prefix has them.
+      - name: Build wayland >= 1.23 into the FEL prefix
+        run: |
+          export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/fel-prefix/lib/pkgconfig:$GITHUB_WORKSPACE/fel-prefix/share/pkgconfig:${PKG_CONFIG_PATH:-}"
+          if pkg-config --atleast-version=1.23 wayland-client && \
+             pkg-config --atleast-version=1.38 wayland-protocols; then
+            echo "prefix already satisfies mpv's wayland requirements"; exit 0
+          fi
+          curl -fsSLO https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.23.1/wayland-1.23.1.tar.gz
+          tar xf wayland-1.23.1.tar.gz
+          meson setup wayland-1.23.1/_b wayland-1.23.1 \
+            --prefix="$GITHUB_WORKSPACE/fel-prefix" --libdir=lib --buildtype=release \
+            -Ddocumentation=false -Dtests=false -Ddtd_validation=false
+          meson install -C wayland-1.23.1/_b
+          curl -fsSLO https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.41/wayland-protocols-1.41.tar.gz
+          tar xf wayland-protocols-1.41.tar.gz
+          meson setup wayland-protocols-1.41/_b wayland-protocols-1.41 \
+            --prefix="$GITHUB_WORKSPACE/fel-prefix" -Dtests=false
+          meson install -C wayland-protocols-1.41/_b
+          pkg-config --atleast-version=1.23 wayland-client
+          pkg-config --atleast-version=1.38 wayland-protocols
 
       - name: Checkout Omniphony (renderer source)
         uses: actions/checkout@v5
@@ -152,7 +179,8 @@ jobs:
         run: |
           PREFIX="$GITHUB_WORKSPACE/fel-prefix"
           # FEL prefix FIRST so its libplacebo/ffmpeg shadow the system ones.
-          export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:${{ github.workspace }}/sysroot/usr/lib/pkgconfig"
+          # share/pkgconfig: wayland-protocols installs its .pc there.
+          export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig:${{ github.workspace }}/sysroot/usr/lib/pkgconfig"
           export LD_LIBRARY_PATH="$PREFIX/lib:${{ github.workspace }}/sysroot/usr/lib"
           export PATH="$PREFIX/bin:$PATH"
           cd "$MPV_DIR"


### PR DESCRIPTION
mpv master bumped its wayland requirements (client/cursor/scanner >= 1.23, protocols >= 1.38); the noble runner has 1.22 / 1.34, which killed `build-linux` of v0.5.0-fel-beta.2 at meson setup. macOS and Windows were green (the ffmpeg-mirror fix from #66 did its job).

Rather than dropping the wayland vo (that would regress #59), build wayland 1.23.1 and wayland-protocols 1.41 into the FEL prefix the job already prepends to `PKG_CONFIG_PATH`/`PATH`/`LD_LIBRARY_PATH`, and add `share/pkgconfig` to the mpv step's search path (that's where wayland-protocols lands). The step is pkg-config-guarded, so a cached prefix that already satisfies the versions is a no-op.

A v0.5.0-fel-beta.3 tag will follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)