### PR TITLE
fix(fel-ci): wayland-protocols 1.49 — mpv master uses color-representation-v1

### DIFF
--- a/.github/workflows/build-master-beta.yml
+++ b/.github/workflows/build-master-beta.yml
@@ -105,16 +105,20 @@ jobs:
           echo "libplacebo $(pkg-config --modversion libplacebo)"
           ffmpeg -hide_banner -bsfs | grep -q dovi_split
 
-      # mpv master needs wayland-client/-cursor/-scanner >= 1.23 and
-      # wayland-protocols >= 1.38; noble ships 1.22 / 1.34. Build both into the
-      # FEL prefix (PKG_CONFIG_PATH/PATH already point there for the mpv build,
-      # and the bundler stages prefix libs). Runs on cache hits too — the
-      # pkg-config guard makes it a no-op once the prefix has them.
+      # mpv master needs wayland-client/-cursor/-scanner >= 1.23 (hard meson
+      # requirement) and in practice wayland-protocols >= 1.44: its meson floor
+      # says 1.38, but wayland_common.c references color-representation-v1,
+      # whose XML only ships from protocols 1.44 — with older protocols the
+      # header is not generated and the build dies on implicit declarations.
+      # Noble ships 1.22 / 1.34. Build both into the FEL prefix
+      # (PKG_CONFIG_PATH/PATH already point there for the mpv build, and the
+      # bundler stages prefix libs). Runs on cache hits too — the pkg-config
+      # guard makes it a no-op once the prefix has them.
       - name: Build wayland >= 1.23 into the FEL prefix
         run: |
           export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/fel-prefix/lib/pkgconfig:$GITHUB_WORKSPACE/fel-prefix/share/pkgconfig:${PKG_CONFIG_PATH:-}"
           if pkg-config --atleast-version=1.23 wayland-client && \
-             pkg-config --atleast-version=1.38 wayland-protocols; then
+             pkg-config --atleast-version=1.44 wayland-protocols; then
             echo "prefix already satisfies mpv's wayland requirements"; exit 0
           fi
           curl -fsSLO https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.23.1/wayland-1.23.1.tar.gz
@@ -123,13 +127,13 @@ jobs:
             --prefix="$GITHUB_WORKSPACE/fel-prefix" --libdir=lib --buildtype=release \
             -Ddocumentation=false -Dtests=false -Ddtd_validation=false
           meson install -C wayland-1.23.1/_b
-          curl -fsSLO https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.41/wayland-protocols-1.41.tar.gz
-          tar xf wayland-protocols-1.41.tar.gz
-          meson setup wayland-protocols-1.41/_b wayland-protocols-1.41 \
+          curl -fsSLO https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.49/wayland-protocols-1.49.tar.gz
+          tar xf wayland-protocols-1.49.tar.gz
+          meson setup wayland-protocols-1.49/_b wayland-protocols-1.49 \
             --prefix="$GITHUB_WORKSPACE/fel-prefix" -Dtests=false
-          meson install -C wayland-protocols-1.41/_b
+          meson install -C wayland-protocols-1.49/_b
           pkg-config --atleast-version=1.23 wayland-client
-          pkg-config --atleast-version=1.38 wayland-protocols
+          pkg-config --atleast-version=1.44 wayland-protocols
 
       - name: Checkout Omniphony (renderer source)
         uses: actions/checkout@v5


### PR DESCRIPTION
Second half of the v0.5.0-fel wayland saga: 1.41 satisfied mpv's declared meson floor (>= 1.38), but `wayland_common.c` on master references `color-representation-v1`, whose XML only ships from wayland-protocols **1.44** — with 1.41 the header is never generated and build-linux dies on implicit declarations. Install 1.49 (current) and raise the step's guard to 1.44 so a cached prefix carrying 1.41 rebuilds. (The transient freedesktop 504 from the first beta.3 run passed on rerun; wayland 1.23.1 itself built fine.)

A v0.5.0-fel-beta.4 tag will follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)