### PR TITLE
release: ship libmpv as a separate Windows asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,8 +528,11 @@ jobs:
           mkdir -p staging-libmpv/include/mpv
           cp "build/mpv-${MPV_TAG}/include/mpv/"*.h staging-libmpv/include/mpv/
           mv staging-libmpv/orender.h staging-libmpv/include/
-          # MSVC can't link the MinGW import library; it builds its own from this.
-          python3 scripts/make-import-def.py \
+          # MSVC can't link the MinGW import library; it builds its own from
+          # this. Restrict it to the client API: the DLL also exports the Lua
+          # interpreter mpv links statically, and an import library carrying
+          # luaL_* would collide with a consumer's own Lua for no reason.
+          python3 scripts/make-import-def.py --prefix mpv_ \
             "staging-libmpv/$(basename "$dll")" staging-libmpv/mpv.def
           cp packaging/libmpv-README.md staging-libmpv/README.md
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,20 @@ on:
       # build-fel.yml on the master track; keep them off the stable release.
       - '!*-fel*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Version label used in the asset filenames (e.g. v0.5.0). Defaults to
+          the ref name. Set it when rebuilding an asset for an already-published
+          release.
+        required: false
+        default: ''
+      windows_only:
+        description: >-
+          Skip the Linux and macOS builds. Used to produce a Windows-only asset
+          (e.g. the libmpv SDK) for a release that already shipped.
+        type: boolean
+        default: false
 
 env:
   MPV_TAG: v0.41.0
@@ -25,9 +39,16 @@ env:
   # ship an old liborender (config parsed differently → default room). Bump
   # this one line on each release.
   OMNIPHONY_REF: v0.5.0
+  # Version label baked into the asset filenames: the tag on a tag push, the
+  # `version` input on a manual run. The zip steps flatten any '/' — a branch
+  # ref name would otherwise make `zip` write into a directory that isn't there.
+  VERSION: ${{ inputs.version || github.ref_name }}
 
 jobs:
   build-linux:
+    # `windows_only` manual runs rebuild a Windows asset for a release that
+    # already shipped; the other platforms would just burn CI time.
+    if: ${{ !inputs.windows_only }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -132,7 +153,7 @@ jobs:
           cp "build/mpv-${MPV_TAG}/_b/mpv" staging/
           cp README.md staging/
           cd staging
-          zip -r "../mpv-omniphony-${GITHUB_REF_NAME}-linux-x86_64.zip" .
+          zip -r "../mpv-omniphony-${VERSION//\//-}-linux-x86_64.zip" .
 
       - uses: actions/upload-artifact@v6
         with:
@@ -474,7 +495,7 @@ jobs:
         run: |
           ls -la staging/
           cd staging
-          zip -r "../mpv-omniphony-${GITHUB_REF_NAME}-windows-x86_64.zip" .
+          zip -r "../mpv-omniphony-${VERSION//\//-}-windows-x86_64.zip" .
 
       - uses: actions/upload-artifact@v6
         with:
@@ -520,7 +541,7 @@ jobs:
         run: |
           ls -la staging-libmpv/
           cd staging-libmpv
-          zip -r "../libmpv-omniphony-${GITHUB_REF_NAME}-windows-x86_64.zip" .
+          zip -r "../libmpv-omniphony-${VERSION//\//-}-windows-x86_64.zip" .
 
       - uses: actions/upload-artifact@v6
         with:
@@ -530,6 +551,7 @@ jobs:
   # macOS (Apple Silicon): mpv builds natively, so liborender is built in the
   # same job (like the Linux job, unlike the Windows cross-compile split).
   build-macos:
+    if: ${{ !inputs.windows_only }}
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v5
@@ -658,7 +680,7 @@ jobs:
 
           # Single artifact: the .app. CLI users run mpv-omniphony.app/Contents/MacOS/mpv
           # (the binary needs Contents/Frameworks + Resources for MoltenVK/ICD).
-          zip -ry "${GITHUB_WORKSPACE}/mpv-omniphony-${GITHUB_REF_NAME}-macos-arm64.zip" mpv-omniphony.app
+          zip -ry "${GITHUB_WORKSPACE}/mpv-omniphony-${VERSION//\//-}-macos-arm64.zip" mpv-omniphony.app
 
       - uses: actions/upload-artifact@v6
         with:
@@ -666,6 +688,10 @@ jobs:
           path: mpv-omniphony-*-macos-arm64.zip
 
   release:
+    # Tag pushes only. A manual run is a build (smoke test, or an asset for an
+    # already-published release): it uploads artifacts and stops there, rather
+    # than drafting a release named after a branch.
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,6 +481,52 @@ jobs:
           name: mpv-omniphony-windows-x86_64
           path: mpv-omniphony-*-windows-x86_64.zip
 
+      # Second Windows asset for embedders (mgth/mpv-omniphony#50): the same
+      # build's libmpv, kept out of the player zip so a plain user download does
+      # not grow by another ~15 MB of DLL + headers.
+      - name: Stage libmpv SDK
+        run: |
+          B="build/mpv-${MPV_TAG}/_b"
+          # mpv's `libmpv` meson option defaults to true, so the cplayer build
+          # above already produced the shared library — fail loudly rather than
+          # ship an empty SDK if a future mpv bump flips that default. The DLL
+          # carries the client-API major (libmpv-2.dll today); glob it so an API
+          # bump renames the file instead of breaking the job.
+          dll=$(ls "$B"/libmpv-*.dll 2>/dev/null | head -1)
+          implib=$(ls "$B"/libmpv*.dll.a 2>/dev/null | head -1)
+          [ -n "$dll" ] && [ -n "$implib" ] \
+            || { echo "!! libmpv not built"; ls "$B"; exit 1; }
+          # Start from the player bundle so every transitive runtime DLL comes
+          # along (mpv.exe is libmpv plus a main(), so its import closure is a
+          # superset of libmpv's). Copying the directory rather than *.dll also
+          # keeps PE files with Unix-style versioned names (libgsm.dll.1.0.23).
+          cp -a staging staging-libmpv
+          rm -f staging-libmpv/mpv.exe staging-libmpv/mpv.com
+          cp "$dll" staging-libmpv/
+          cp "$implib" staging-libmpv/   # MinGW/clang import library
+          mkdir -p staging-libmpv/include/mpv
+          cp "build/mpv-${MPV_TAG}/include/mpv/"*.h staging-libmpv/include/mpv/
+          mv staging-libmpv/orender.h staging-libmpv/include/
+          # MSVC can't link the MinGW import library; it builds its own from this.
+          python3 scripts/make-import-def.py \
+            "staging-libmpv/$(basename "$dll")" staging-libmpv/mpv.def
+          cp packaging/libmpv-README.md staging-libmpv/README.md
+        shell: bash
+
+      - name: Verify staged libmpv imports resolve
+        run: python3 scripts/check-bundle-imports.py staging-libmpv
+
+      - name: Package libmpv zip
+        run: |
+          ls -la staging-libmpv/
+          cd staging-libmpv
+          zip -r "../libmpv-omniphony-${GITHUB_REF_NAME}-windows-x86_64.zip" .
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: libmpv-omniphony-windows-x86_64
+          path: libmpv-omniphony-*-windows-x86_64.zip
+
   # macOS (Apple Silicon): mpv builds natively, so liborender is built in the
   # same job (like the Linux job, unlike the Windows cross-compile split).
   build-macos:
@@ -635,6 +681,10 @@ jobs:
 
       - uses: actions/download-artifact@v7
         with:
+          name: libmpv-omniphony-windows-x86_64
+
+      - uses: actions/download-artifact@v7
+        with:
           name: mpv-omniphony-macos-arm64
 
       # Resolve the engine commit this build embeds, so the relocated release is
@@ -687,6 +737,15 @@ jobs:
             `xattr -dr com.apple.quarantine /path/to/mpv-omniphony.app`, or
             right-click → Open the first time.
 
+            **Embedding (Windows):** `libmpv-omniphony-…-windows-x86_64.zip`
+            carries `libmpv-2.dll` from this same build, with `libmpv.dll.a`
+            (MinGW), `mpv.def` (run `lib /def:mpv.def /name:libmpv-2.dll
+            /out:mpv.lib /MACHINE:X64` for MSVC), the `mpv/` headers and the
+            runtime DLLs. Spatial decoding works there too, but the engine is
+            searched next to the **host executable**, not next to
+            `libmpv-2.dll` — set `$ORENDER_LIBRARY` or the
+            `ad-orender-library` option if you put `orender.dll` elsewhere.
+
             **Upgrading?** The overlay is now built in: delete any
             `omniphony-overlay.lua` you previously copied into your mpv
             `scripts/` directory. A leftover copy is harmless (it self-disables
@@ -711,4 +770,5 @@ jobs:
           files: |
             mpv-omniphony-*-linux-x86_64.zip
             mpv-omniphony-*-windows-x86_64.zip
+            libmpv-omniphony-*-windows-x86_64.zip
             mpv-omniphony-*-macos-arm64.zip

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ scripts/regenerate-patches-master.sh # rebuild patches-master/ from `orender-mas
 meson-options.txt       # canonical `orender` meson feature option
 packaging/PKGBUILD          # Arch package against v0.41.0 (provides/conflicts mpv)
 packaging/PKGBUILD-master   # Arch -git package tracking master HEAD
+packaging/libmpv-README.md  # shipped inside the Windows libmpv SDK zip
 .github/workflows/ci.yml             # weekly drift check on v0.41.0
 .github/workflows/build-master.yml   # daily smoke test on master HEAD
 ```
@@ -66,6 +67,16 @@ scripts/regenerate-patches.sh /path/to/mpv-fork v0.41.0
 Running it (playback, the shared `~/.config/omniphony/config.yaml`, OSC, Studio
 supervision and the on-video overlay) is documented in the
 [usage guide](https://github.com/mgth/Omniphony/blob/main/docs/mpv-omniphony.md).
+
+### Embedding (libmpv)
+
+Windows releases carry a second asset,
+`libmpv-omniphony-<tag>-windows-x86_64.zip`: `libmpv-2.dll` from the same
+build, with the MinGW import library, an `mpv.def` for MSVC, the `mpv/`
+headers and the runtime DLLs. Details in
+[`packaging/libmpv-README.md`](packaging/libmpv-README.md) — note it is a
+**GPL-3.0-or-later** libmpv (mpv `-Dgpl=true` combined with liborender), not
+the LGPL build upstream publishes.
 
 ## mpv fork workflow
 

--- a/packaging/libmpv-README.md
+++ b/packaging/libmpv-README.md
@@ -1,0 +1,66 @@
+# libmpv-omniphony (Windows x86_64)
+
+`libmpv` built from [mpv-omniphony](https://github.com/mgth/mpv-omniphony) —
+mpv plus the `ad_orender` spatial audio decoder. Same build as the
+`mpv-omniphony-…-windows-x86_64.zip` player bundle, exposed as a library for
+embedders.
+
+## Contents
+
+```
+libmpv-2.dll        the library (client API, same ABI as upstream libmpv)
+libmpv.dll.a        import library for MinGW / clang toolchains
+mpv.def             export list, to build an import library for MSVC
+include/mpv/*.h     client.h, render.h, render_gl.h, stream_cb.h
+include/orender.h   engine ABI header (only needed to load liborender yourself)
+orender.dll         the spatial rendering engine, loaded at runtime
+*.dll               MinGW runtime + ffmpeg/libplacebo/libass/… dependencies
+```
+
+Keep every DLL next to your executable (or on `PATH`); they are the exact set
+`libmpv-2.dll` was built against.
+
+## Linking
+
+**MSVC** — generate the import library from `mpv.def`, then link `mpv.lib`:
+
+```
+lib /def:mpv.def /name:libmpv-2.dll /out:mpv.lib /MACHINE:X64
+```
+
+**MinGW / clang** — link `libmpv.dll.a` directly (`-lmpv` with this directory
+on the library path).
+
+## Spatial audio from an embedder
+
+Spatial decoding is on by default for the codecs `ad_orender` claims. The
+engine is loaded at runtime and searched in this order:
+
+1. the `ad-orender-library` option (`mpv_set_option_string`)
+2. the `ORENDER_LIBRARY` environment variable
+3. the engine deployed by Omniphony Studio (per-user data dir)
+4. **next to the host executable**
+5. the system library path
+
+Step 4 resolves against *your* `.exe`, not against `libmpv-2.dll`: if you keep
+the DLLs in a subdirectory, point mpv at the engine explicitly rather than
+relying on it. An engine whose ABI does not match is rejected with a log line
+and mpv falls back to its native decoders.
+
+The decoder **bridge** (Dolby/DTS front-ends) is not bundled — licensing
+constraints mean you fetch it yourself from
+[harletty-bridge](https://github.com/harletty/harletty-bridge/releases) and set
+the `ad-orender-bridge-path` option.
+
+## License — GPL-3.0-or-later
+
+This is a **GPL** libmpv, not the LGPL build published upstream: mpv is
+compiled with `-Dgpl=true` and combined with `liborender`
+(GPL-3.0-or-later), so the combined work — and any application you link it
+into — is **GPL-3.0-or-later**. If you need LGPL terms, use an upstream libmpv
+build; it has no spatial decoder.
+
+Corresponding source: mpv at the tag recorded in the release notes plus this
+repo's `patches/`, and `liborender` from
+[Omniphony](https://github.com/mgth/Omniphony). Bundled third-party libraries:
+see `THIRD-PARTY-NOTICES.md` in the mpv-omniphony repository.

--- a/scripts/make-import-def.py
+++ b/scripts/make-import-def.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Emit an MSVC-style .def file listing a DLL's exported symbols.
+
+The Windows libmpv bundle ships MinGW's import library (libmpv.dll.a), which
+MSVC toolchains cannot link against. With this .def they generate their own:
+
+    lib /def:mpv.def /name:libmpv-2.dll /out:mpv.lib /MACHINE:X64
+
+objdump's export table layout differs between binutils versions (the symbol
+either follows a `+base[N] hint` prefix or stands alone after the ordinal), so
+match both and take the union. A plausibility floor turns a future layout
+change into a failed build instead of a silently truncated .def.
+
+Usage: make-import-def.py <dll> <out.def>
+Env:   OBJDUMP  objdump binary to use (default: x86_64-w64-mingw32-objdump)
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+# libmpv exports ~90 symbols; a handful means the parse broke, not a small API.
+MIN_EXPORTS = 50
+
+# "[   0] +base[   1]  0000 mpv_client_api_version"
+BASE_HINT_RE = re.compile(r"^\s*\[\s*\d+\]\s+\+base\[\s*\d+\]\s+\S+\s+(\S+)\s*$", re.M)
+# "[   0] mpv_client_api_version"
+PLAIN_RE = re.compile(r"^\s*\[\s*\d+\]\s+([A-Za-z_][\w@?$.]*)\s*$", re.M)
+IDENT_RE = re.compile(r"[A-Za-z_?][\w@?$.]*")
+# Placeholder token printed instead of a name when only the address is known.
+NOT_A_SYMBOL = {"RVA"}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    dll, out_path = sys.argv[1], sys.argv[2]
+
+    tool = os.environ.get("OBJDUMP", "x86_64-w64-mingw32-objdump")
+    dump = subprocess.run(
+        [tool, "-p", dll], capture_output=True, text=True, check=True
+    ).stdout
+
+    names = set(BASE_HINT_RE.findall(dump)) | set(PLAIN_RE.findall(dump))
+    names = {n for n in names if n not in NOT_A_SYMBOL and IDENT_RE.fullmatch(n)}
+
+    if len(names) < MIN_EXPORTS:
+        print(
+            f"error: parsed only {len(names)} exports from {dll} "
+            f"(expected >= {MIN_EXPORTS}) — objdump export layout changed?",
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(out_path, "w") as fh:
+        fh.write("EXPORTS\n")
+        for name in sorted(names):
+            fh.write(f"{name}\n")
+
+    print(f"wrote {out_path} ({len(names)} exports)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/make-import-def.py
+++ b/scripts/make-import-def.py
@@ -11,7 +11,11 @@ either follows a `+base[N] hint` prefix or stands alone after the ordinal), so
 match both and take the union. A plausibility floor turns a future layout
 change into a failed build instead of a silently truncated .def.
 
-Usage: make-import-def.py <dll> <out.def>
+A prefix filter keeps the .def down to the API the DLL is meant to expose. Our
+libmpv-2.dll also exports the Lua interpreter it links statically; an import
+library carrying `luaL_*` would collide with a consumer's own Lua for no reason.
+
+Usage: make-import-def.py [--prefix PREFIX] <dll> <out.def>
 Env:   OBJDUMP  objdump binary to use (default: x86_64-w64-mingw32-objdump)
 """
 
@@ -20,8 +24,9 @@ import re
 import subprocess
 import sys
 
-# libmpv exports ~90 symbols; a handful means the parse broke, not a small API.
-MIN_EXPORTS = 50
+# libmpv exports 54 mpv_* symbols; a handful means the parse broke, not a small
+# API. Kept well under that so a few client-API additions/removals don't trip it.
+MIN_EXPORTS = 40
 
 # "[   0] +base[   1]  0000 mpv_client_api_version"
 BASE_HINT_RE = re.compile(r"^\s*\[\s*\d+\]\s+\+base\[\s*\d+\]\s+\S+\s+(\S+)\s*$", re.M)
@@ -33,10 +38,15 @@ NOT_A_SYMBOL = {"RVA"}
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
+    argv = sys.argv[1:]
+    prefix = ""
+    if len(argv) > 1 and argv[0] == "--prefix":
+        prefix = argv[1]
+        argv = argv[2:]
+    if len(argv) != 2:
         print(__doc__, file=sys.stderr)
         return 2
-    dll, out_path = sys.argv[1], sys.argv[2]
+    dll, out_path = argv
 
     tool = os.environ.get("OBJDUMP", "x86_64-w64-mingw32-objdump")
     dump = subprocess.run(
@@ -45,11 +55,13 @@ def main() -> int:
 
     names = set(BASE_HINT_RE.findall(dump)) | set(PLAIN_RE.findall(dump))
     names = {n for n in names if n not in NOT_A_SYMBOL and IDENT_RE.fullmatch(n)}
+    names = {n for n in names if n.startswith(prefix)}
 
     if len(names) < MIN_EXPORTS:
         print(
             f"error: parsed only {len(names)} exports from {dll} "
-            f"(expected >= {MIN_EXPORTS}) — objdump export layout changed?",
+            f"(prefix {prefix!r}, expected >= {MIN_EXPORTS}) — "
+            "objdump export layout changed?",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
Closes #50.

`libmpv` is a default-on meson option, so the Windows job has always been
building the shared library — it just never left the build directory. The
release zip carried `mpv.exe` + `mpv.com` + `orender.dll` and nothing an
embedder could link against.

## What this adds

A second Windows artifact, `libmpv-omniphony-<tag>-windows-x86_64.zip`, rather
than growing the 73 MB player zip with an SDK most users never open:

```
libmpv-2.dll        same build as the player bundle
libmpv.dll.a        MinGW/clang import library
mpv.def             export list -> lib /def:mpv.def ... /out:mpv.lib for MSVC
include/mpv/*.h     client.h, render.h, render_gl.h, stream_cb.h
include/orender.h   engine ABI header
orender.dll + *.dll runtime closure, copied from the player staging dir
README.md           packaging/libmpv-README.md
```

Staging starts from a copy of the player bundle (`cp -a staging staging-libmpv`
minus the two executables): `mpv.exe` is libmpv plus a `main()`, so its import
closure is a superset of libmpv's, and copying the directory — not `*.dll` —
keeps the PE files with Unix-style versioned names. `check-bundle-imports.py`
then runs over the SDK staging too, so a skewed prebuilt fails the job here as
it does for the player.

`scripts/make-import-def.py` generates `mpv.def` from the DLL's export table.
objdump prints exports in two layouts depending on the binutils version, so it
matches both and takes the union, with a 50-export floor so a layout change
fails the build instead of shipping a truncated `.def`. Verified locally
against a real MinGW-readable DLL: 78 exports parsed, identical to
`objdump -p | awk '{print $NF}'` minus the `RVA` placeholder rows.

## Caveats documented in the bundled README

- The engine loader's exe-dir candidate resolves against the **host
  executable**, not against `libmpv-2.dll` (`GetModuleFileNameW(NULL, ...)`), so
  an embedder keeping the DLLs in a subdirectory must set `ORENDER_LIBRARY` or
  the `ad-orender-library` option.
- This is a **GPL-3.0-or-later** libmpv (mpv `-Dgpl=true` combined with
  liborender), not the LGPL build upstream publishes.

## Testing

Not exercised end to end — the Windows job only runs on a `v*` tag, and the
libmpv filename guard (`libmpv-*.dll` / `libmpv*.dll.a` globs) is the part that
can only be confirmed on CI. Locally verified: workflow YAML parses, both step
lists and the release `files:` list are as intended, and the `.def` generator
was run against real DLLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)